### PR TITLE
In python3, input() returns a string, but in python2, input() eval's the string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ import sys
 extra = {}
 if sys.version_info >= (3,):
     extra['use_2to3'] = False
-
+else:
+    input = raw_input
 
 # set up extension modules
 if 'install' in sys.argv or 'bdist_egg' in sys.argv:


### PR DESCRIPTION
This means that when tying to run
setup.py in python2, the following error is raised:

[i] Do you want to install with C-modules (requires Cython)? (Y/N) y
Traceback (most recent call last):
File "setup.py", line 21, in <module>
    answer = input("[i] Do you want to install with C-modules (requires Cython)? (Y/N) ")
    File "<string>", line 1, in <module>
NameError: name 'y' is not defined

I haven't tested my alteration on python3, but it should be ok. 
