### PR TITLE
added test (stubs) for two more modules

### DIFF
--- a/lingpy/basic/parser.py
+++ b/lingpy/basic/parser.py
@@ -14,6 +14,7 @@ import pickle
 import codecs
 
 from six import text_type as str
+from six import string_types
 
 from ..settings import rcParams
 from ..read.qlc import read_qlc
@@ -37,7 +38,7 @@ class QLCParser(object):
         loaded = False
 
         # check for existing cache-directory
-        if type(filename) == str:
+        if isinstance(filename, string_types):
             if os.path.isdir('__lingpy__'):
                 # check for file extension
                 if filename[-3:].lower() in ['qlc','csv']:
@@ -84,7 +85,7 @@ class QLCParser(object):
         internal_import = False
 
         # check whether it's a dictionary from which we load
-        if type(filename) == dict:
+        if isinstance(filename, dict):
             input_data = filename
             if 'filename' not in input_data:
                 self.filename = rcParams['filename']
@@ -117,10 +118,10 @@ class QLCParser(object):
                 self.filename = filename
         
         # raise an error otherwise
-        elif type(filename) == str:
+        elif isinstance(filename, string_types):
             raise IOError("[ERROR] Input file '{0}' does not exist.".format(filename))
         else:
-            raise TypeError("[ERROR] Unrecognized type for 'filename' arguemnt: {0}".format(type(filename).__name__))
+            raise TypeError("[ERROR] Unrecognized type for 'filename' argument: {0}".format(type(filename).__name__))
 
         # load the configuration file
         if not conf:

--- a/lingpy/basic/tree.py
+++ b/lingpy/basic/tree.py
@@ -185,5 +185,3 @@ class Tree(PhyloNode):
             else:
                 matrix += [[randint(0,max_state),randint(0,max_state)]]
         return matrix
-
-

--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+from lingpy.tests.util import test_data
+
+
+class TestParser(TestCase):
+    def test_Parser(self):
+        from lingpy.basic.parser import QLCParser
+
+        parser = QLCParser(test_data('KSL.qlc'))
+        assert len(parser)

--- a/lingpy/tests/basic/test_tree.py
+++ b/lingpy/tests/basic/test_tree.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from lingpy.tests.util import test_data
+
+
+class TestTree(TestCase):
+    def test_init(self):
+        from lingpy.basic.tree import Tree
+
+        Tree([])


### PR DESCRIPTION
I added test (stubs) for `lingpy.basic.tree` and `lingpy.basic.parser`. In particular `lingpy.basic.parser` contains some rather difficult to test code. The various ways in which the input for a `Parser` instance are looked up should be unified and factored out into some sort of input lookup function which can be shared across modules. In particular the implicit cache protocol - i.e. looking for pickle files in an (AFAIKT undocumented) `__lingpy__` directory (relative to the current working directory) - should either be centralized and documented or thrown out.
