### PR TITLE
refactored the caching mechanism

### DIFF
--- a/lingpy/cache.py
+++ b/lingpy/cache.py
@@ -1,0 +1,36 @@
+# *-* coding: utf-8 *-*
+"""Implements the lingpy cache.
+
+Some operations in lingpy may be time consuming, so we provide a mechanism to cache the
+results of these operations.
+"""
+from __future__ import unicode_literals, print_function, absolute_import, division
+import pickle
+
+from pathlib import Path
+from appdirs import user_cache_dir
+
+
+DIR = Path(user_cache_dir('lingpy'))
+
+
+def path(filename):
+    if not isinstance(filename, Path):
+        filename = Path(filename)
+
+    if filename.suffix.lower() in ['.qlc', '.csv']:
+        filename = Path(filename.stem + '.bin')
+
+    return DIR.joinpath(filename.name)
+
+
+def load(filename):
+    with path(filename).open('rb') as fp:
+        return pickle.load(fp)
+
+
+def dump(data, filename):
+    if not DIR.exists():
+        DIR.mkdir(parents=True)  # pragma: no cover
+    with path(filename).open('wb') as fp:
+        pickle.dump(data, fp)

--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -1,11 +1,33 @@
+import os
 from unittest import TestCase
 
 from lingpy.tests.util import test_data
 
 
 class TestParser(TestCase):
-    def test_Parser(self):
+    def setUp(self):
         from lingpy.basic.parser import QLCParser
 
-        parser = QLCParser(test_data('KSL.qlc'))
-        assert len(parser)
+        self.parser = QLCParser(test_data('KSL.qlc'))
+
+    def test_cache(self):
+        from lingpy.basic.parser import QLCParser
+        from lingpy.cache import path
+
+        filename = 'lingpy_test.qlc'
+        self.parser.pickle(filename=filename)
+        from_cache = QLCParser(filename)
+        self.assertEqual(self.parser.header, from_cache.header)
+        os.remove(str(path(filename)))
+
+    def test_len(self):
+        assert len(self.parser)
+
+    def test_add_entries(self):
+        # shouldn't this raise an exception?
+        self.parser.add_entries('', 'taxon', lambda t: t.lower())
+
+        # shouldn't this call work?
+        #self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower(), override=True)
+
+        self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower())

--- a/lingpy/tests/test_cache.py
+++ b/lingpy/tests/test_cache.py
@@ -1,0 +1,15 @@
+from __future__ import unicode_literals
+import os
+from unittest import TestCase
+
+
+class TestCache(TestCase):
+    def test_cache(self):
+        from lingpy import cache
+
+        d = {'a': 123}
+        filename = 'lingpy_test.CSV'
+        cache.dump(d, filename)
+        self.assertTrue(cache.path(filename).exists())
+        self.assertEqual(cache.load(filename), d)
+        os.remove(str(cache.path(filename)))

--- a/setup.py
+++ b/setup.py
@@ -55,32 +55,31 @@ except ValueError:
 # set up extension modules
 if 'install' in sys.argv or 'bdist_egg' in sys.argv or 'develop' in sys.argv:
     if True: #this_version == "3":
-
         if with_c:
             extension_path = ['lingpy','algorithm','cython']
             extension_prefix = os.path.join(*extension_path)
             extension_modules = [
-                        Extension(
-                            os.path.join('.'.join(extension_path),'calign'),
-                            [os.path.join(extension_prefix,'calign.c')]
-                            ),
-                        Extension(
-                             os.path.join('.'.join(extension_path),'malign'),
-                            [os.path.join(extension_prefix,'malign.c')]
-                            ),
-                        Extension(
-                            os.path.join('.'.join(extension_path),'talign'),
-                            [os.path.join(extension_prefix,'talign.c')]
-                            ),
-                        Extension(
-                            os.path.join('.'.join(extension_path),'cluster'),
-                            [os.path.join(extension_prefix,'cluster.c')]
-                            ),
-                        Extension(
-                            os.path.join('.'.join(extension_path),'misc'),
-                            [os.path.join(extension_prefix,'misc.c')]
-                            ),
-                        ]
+                Extension(
+                    os.path.join('.'.join(extension_path),'calign'),
+                    [os.path.join(extension_prefix,'calign.c')]
+                    ),
+                Extension(
+                     os.path.join('.'.join(extension_path),'malign'),
+                    [os.path.join(extension_prefix,'malign.c')]
+                    ),
+                Extension(
+                    os.path.join('.'.join(extension_path),'talign'),
+                    [os.path.join(extension_prefix,'talign.c')]
+                    ),
+                Extension(
+                    os.path.join('.'.join(extension_path),'cluster'),
+                    [os.path.join(extension_prefix,'cluster.c')]
+                    ),
+                Extension(
+                    os.path.join('.'.join(extension_path),'misc'),
+                    [os.path.join(extension_prefix,'misc.c')]
+                    ),
+                ]
         else:
             extension_modules = []
 
@@ -92,54 +91,58 @@ if 'install' in sys.argv or 'bdist_egg' in sys.argv or 'develop' in sys.argv:
 else:
     extension_modules = []
 
+requires = [
+    'numpy',
+    'six',
+    'networkx',
+    'appdirs',
+    #'regex',
+    #'matplotlib',
+    #'scipy',
+]
+if sys.version_info < (3, 4):
+    requires.append('pathlib')
+
 # make global name of this version
 thisversion = "2.4.dev"
 setup(
-        name = pkgname,
-        version = thisversion,
-        packages = find_packages(pkg_location),
-        package_dir = pkg_dir,
-        install_requires = [
-		'numpy', 
-		'six',
-		'networkx',
-		#'regex',
-		#'matplotlib',
-		#'scipy',
-	],
-        tests_require=['regex', 'nltk', 'nose', 'coverage'],
-        author = "Johann-Mattis List, Steven Moran, Peter Bouda, Johannes Dellert",
-        author_email = "mattis.list@uni-marburg.de,steven.moran@lmu.de",
-        keywords = [
-            "historical linguistics", 
-            "sequence alignment",
-            "computational linguistics"
-            ],
-        url = "http://lingpy.org",
-        description = "Python library for automatic tasks in historical linguistics",
-        license = "gpl-3.0",
-        platforms = ["unix","linux","windows"],
-        ext_modules=extension_modules,
-        extras_require = {
-            "borrowing" : ["matplotlib","networkx","scipy"]
-            },
-        include_package_data = True,
-        exclude_package_data = {}, #{'':["*.bin"]},
-        package_data = {'':
-            [
-                'data/ipa/sampa.csv',
-                'data/orthography_profiles/*.prf',
-                'tests/test_data/*.csv',
-                'tests/test_data/*.qlc',
-                'tests/test_data/*.msq',
-                'tests/test_data/*.msa',
-                'data/conceptlists/*.tsv',
-                'data/conf/*.rc',
-                'data/models/*/converter',
-                'data/models/*/INFO',
-                'data/models/*/matrix',
-                'data/models/*/scorer'
-                ]},
-        **extra
-        )
-
+    name=pkgname,
+    version=thisversion,
+    packages=find_packages(pkg_location),
+    package_dir=pkg_dir,
+    install_requires=requires,
+    tests_require=['regex', 'nltk', 'nose', 'coverage'],
+    author="Johann-Mattis List, Steven Moran, Peter Bouda, Johannes Dellert",
+    author_email="mattis.list@uni-marburg.de,steven.moran@lmu.de",
+    keywords=[
+        "historical linguistics",
+        "sequence alignment",
+        "computational linguistics"
+    ],
+    url="http://lingpy.org",
+    description="Python library for automatic tasks in historical linguistics",
+    license="gpl-3.0",
+    platforms=["unix", "linux", "windows"],
+    ext_modules=extension_modules,
+    extras_require={
+        "borrowing": ["matplotlib", "networkx", "scipy"]
+    },
+    include_package_data=True,
+    exclude_package_data={},  #{'':["*.bin"]},
+    package_data={
+        '': [
+            'data/ipa/sampa.csv',
+            'data/orthography_profiles/*.prf',
+            'tests/test_data/*.csv',
+            'tests/test_data/*.qlc',
+            'tests/test_data/*.msq',
+            'tests/test_data/*.msa',
+            'data/conceptlists/*.tsv',
+            'data/conf/*.rc',
+            'data/models/*/converter',
+            'data/models/*/INFO',
+            'data/models/*/matrix',
+            'data/models/*/scorer',
+        ]
+    },
+    **extra)


### PR DESCRIPTION
I found the [AppDirs](https://pypi.python.org/pypi/appdirs/) package from the ActiveState people and think this solves the problem of determining platform specific cache dirs nicely (or at least in a documented way we can point to).

Access to the cache is now available to all modules via `lingpy.cache` and the `QLCParser` class was refactored accordingly.

While this change comes at the expense of two additional dependencies, I think it is still worthwhile, because `AppDirs` is small and easy to install and `pathlib` is actually part of the standard library as of python 3.4.
