### PR TITLE
modify sound-class models, data now stored in cache

### DIFF
--- a/lingpy/basic/parser.py
+++ b/lingpy/basic/parser.py
@@ -17,13 +17,7 @@ from six import string_types
 
 from ..settings import rcParams
 from ..read.qlc import read_qlc
-
-# nasty hack to avoid that missing pathlib throws an error upon installation
-# will change it later to more proper style
-try:
-    from lingpy import cache
-except:
-    print(rcParams['W_missing_module'].format('pathlib'))
+from .. import cache
 
 from ..sequence.tokenizer import Tokenizer
 

--- a/lingpy/data/derive.py
+++ b/lingpy/data/derive.py
@@ -29,6 +29,7 @@ from ..settings import rcParams
 from ..algorithm import misc
 from ..convert.strings import scorer2str
 from ..read import *
+from .. import cache
 
 try:
     import networkx as nx
@@ -56,7 +57,7 @@ def _import_sound_classes(filename):
     
     for key in sc_dict.keys():
         for value in sc_dict[key]:
-            print(value,key)
+            if rcParams['debug']: print(value,key)
             sc_repl_dict[value] = key
 
     return sc_repl_dict
@@ -507,9 +508,10 @@ def compile_model(
     sound_classes = _import_sound_classes(os.path.join(new_path,'converter'))
     
     # dump the data
-    outfile = open(os.path.join(new_path,'converter.bin'),'wb')
-    dump(sound_classes,outfile)
-    outfile.close()
+    cache.dump(sound_classes, model+'.converter')
+    #outfile = open(os.path.join(new_path,'converter.bin'),'wb')
+    #dump(sound_classes,outfile)
+    #outfile.close()
     print("... successfully created the converter.")
 
     # try to load the scoring function or the score tree
@@ -549,9 +551,10 @@ def compile_model(
     
     if scorer:
         # dump the data
-        outfile = open(os.path.join(new_path,'scorer.bin'),'wb')
-        dump(scorer,outfile)
-        outfile.close()
+        cache.dump(scorer, model+'.scorer')
+        #outfile = open(os.path.join(new_path,'scorer.bin'),'wb')
+        #dump(scorer,outfile)
+        #outfile.close()
         print("... successfully created the scorer.")
     else:
         print("... no scoring dictionary defined.")
@@ -587,14 +590,14 @@ def compile_dvt(path=''):
 
     # get the path to the models
     if not path:
-        path = os.path.join(
+        file_path = os.path.join(
                 rcParams['_path'],
                 'data',
                 'models',
                 'dvt'
                 )
     elif path in ['evolaemp','el']:
-        path = os.path.join(
+        file_path = os.path.join(
                 rcParams['_path'],
                 'data',
                 'models',
@@ -604,18 +607,18 @@ def compile_dvt(path=''):
         pass
 
     diacritics = codecs.open(
-            os.path.join(path,'diacritics'),
+            os.path.join(file_path,'diacritics'),
             'r',
             'utf-8'
             ).read().replace('\n','').replace('-','')
     vowels = codecs.open(
-            os.path.join(path,'vowels'),
+            os.path.join(file_path,'vowels'),
             'r',
             'utf-8'
             ).read().replace('\n','')
 
     tones = codecs.open(
-            os.path.join(path,'tones'),
+            os.path.join(file_path,'tones'),
             'r',
             'utf-8'
             ).read().replace('\n','')
@@ -627,10 +630,15 @@ def compile_dvt(path=''):
     tones = unicodedata.normalize("NFC", tones)
     
     dvt = (diacritics,vowels,tones)
-
-    outfile = open(os.path.join(path,'dvt.bin'),'wb')
-    dump(dvt,outfile)
-    outfile.close()
+    
+    if path in ['evolaemp', 'el']:
+        cache.dump(dvt, 'dvt_el')
+    else:
+        print('dumpling')
+        cache.dump(dvt, 'dvt')
+    #outfile = open(os.path.join(path,'dvt.bin'),'wb')
+    #dump(dvt,outfile)
+    #outfile.close()
 
     if rcParams['verbose']: print("[i] Diacritics and sound classes were successfully compiled.")
 

--- a/setup.py
+++ b/setup.py
@@ -141,16 +141,15 @@ setup(
     },
     **extra)
 
-if 'sdist' not in sys.argv:
-    from glob import glob
-    tmp_path = os.path.split(os.path.abspath(__file__))[0]
-    print(tmp_path)
-    binary_files = glob(os.path.join(tmp_path,'lingpy','data','models','*','*.bin'))
-    for binary_file in binary_files:
-        print(binary_file)
-        os.remove(binary_file)
-    
-    sys.path = sorted(sys.path, reverse=True)
-    from lingpy import *
-    rc(schema = 'asjp')
-    print("[i] LingPy was successfully installed on your system.")
+#if 'sdist' not in sys.argv:
+#    from glob import glob
+#    tmp_path = os.path.split(os.path.abspath(__file__))[0]
+#    binary_files = glob(os.path.join(tmp_path,'lingpy','data','models','*','*.bin'))
+#    for binary_file in binary_files:
+#        print(binary_file)
+#        os.remove(binary_file)
+#    
+#    sys.path = sorted(sys.path, reverse=True)
+#    from lingpy import *
+#    rc(schema = 'asjp')
+#    print("[i] LingPy was successfully installed on your system.")


### PR DESCRIPTION
This commit tries to handle quite a few of the problems we were discussing over the weakend:
- store binary files in the cache (sound-class models created by model.py and derive.py)
- remove "import lingpy" from setup.py, thus guaranteeing that no nasty workarounds are needed
- remove ugly import manipulation in parser.py
