### PR TITLE
closes #133

### DIFF
--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -12,12 +12,19 @@ class TestParser(TestCase):
 
     def test_cache(self):
         from lingpy.basic.parser import QLCParser
+        from lingpy.basic.wordlist import Wordlist
         from lingpy.cache import path
 
         filename = 'lingpy_test.qlc'
         self.parser.pickle(filename=filename)
         from_cache = QLCParser.unpickle(filename)
         self.assertEqual(self.parser.header, from_cache.header)
+        os.remove(str(path(filename)))
+
+        wl = Wordlist(test_data('KSL.qlc'))
+        wl.pickle(filename=filename)
+        from_cache = Wordlist.unpickle(filename)
+        self.assert_(from_cache._class)
         os.remove(str(path(filename)))
 
     def test_len(self):


### PR DESCRIPTION
This PR re-introduces the special handling of a `QLCParser._class` when (un)pickling. This is necessary, because the `_class` dictionary may contain objects which cannot be pickled, e.g. `lambda` functions.
