### PR TITLE
Fixed typo in Readme for issue 150

### DIFF
--- a/lingpy/README.md
+++ b/lingpy/README.md
@@ -18,7 +18,7 @@ The library in it's current state consist of the following modules:
 
 When loading LingPy in a python session using either the 
 ```python
->>> from lingpy impor t*
+>>> from lingpy import *
 ```
 or the 
 ```python


### PR DESCRIPTION
Fixed typo in Readme for issue #150: https://github.com/lingpy/lingpy/issues/150
Via 24PullRequests.com
