### PR TITLE
Tokenizer without orthography profile fails invisibly if regex module isn't installed. 

### DIFF
--- a/lingpy/sequence/tokenizer.py
+++ b/lingpy/sequence/tokenizer.py
@@ -41,7 +41,7 @@ class Tokenizer(object):
     -----
 
     The Tokenizer reads in an orthography profile and calls a helper 
-    class to build a trie data structure, which stores the possible Unicode 
+    class to build a tree data structure, which stores the possible Unicode 
     character combinations that are specified in the orthography profile 
     and appear in the data source.
 
@@ -115,7 +115,7 @@ class Tokenizer(object):
 
         # orthography profile processing
         if self.orthography_profile:
-            # read in orthography profile and create a trie structure for tokenization
+            # read in orthography profile and create a tree structure for tokenization
             self.root = createTree(self.orthography_profile)
 
             # store column labels from the orthography profile
@@ -172,7 +172,7 @@ class Tokenizer(object):
                 self.mappings[grapheme, self.column_labels[i].lower()] = token
                 log.debug('%s %s' % (grapheme, self.column_labels[i].lower()))
 
-        # print the trie structure if debug mode is on
+        # print the tree structure if debug mode is on
         if log.get_logger().getEffectiveLevel() <= logging.INFO:
             log.debug("A graphical representation of your orthography profile in a tree ('*' denotes sentinels):\n")
             printTree(self.root, "")
@@ -531,7 +531,7 @@ class Tokenizer(object):
 # ---------- Tree node --------
 class TreeNode(object):
     """
-    Private class that creates the trie data structure from the orthography profile for parsing.
+    Private class that creates the tree data structure from the orthography profile for parsing.
     """
 
     def __init__(self, char):

--- a/lingpy/sequence/tokenizer.py
+++ b/lingpy/sequence/tokenizer.py
@@ -47,7 +47,7 @@ class Tokenizer(object):
 
     For example, an orthography profile might specify that in source X 
     <uu> is a single grapheme (Unicode parlance: tailored grapheme) and 
-    thererfore it should be chunked as so. Given an orthography profile and 
+    therefore it should be chunked as so. Given an orthography profile and 
     some data to parse, the process would look like this:
 
     input string example: uubo uubo
@@ -104,8 +104,6 @@ class Tokenizer(object):
 	b aː tʃ    
 
     """
-    grapheme_pattern = re.compile("\X", re.UNICODE)
-
     def __init__(self, orthography_profile=None):
         if orthography_profile and not os.path.exists(orthography_profile):
             raise ValueError("The orthography profile you specified does not exist!")
@@ -136,7 +134,15 @@ class Tokenizer(object):
                 self.op_rules = []
                 self.op_replacements = []
                 self._init_rules(self.orthography_profile_rules)
-
+        else:
+            try:
+                import regex as re
+            except ImportError:
+                raise ImportError(
+                    "Please install the `regex` module to use Tokenizer without an orthography_profile."
+                )
+            self.grapheme_pattern = re.compile("\X", re.UNICODE)
+            
         log.debug("Orthography profile: %s" % self.orthography_profile)
         log.debug("Orthography rules: %s" % self.orthography_profile_rules)
         log.debug("Columns labels: %s" % self.column_labels)


### PR DESCRIPTION
Using Wordlist.tokenize() without an orthography profiles files invisibly if regex module isn't installed. Nothing in tokenised, so any output is without tokens. e.g. 

* 1. Make sure regex is not installed:

```
⏚ [simon@minerva5:~/Desktop/lp-err] % python run.py
[WARNING] Module 'regex' could not be loaded. Some methods may not work properly.
[WARNING] Module 'regex' could not be loaded. Some methods may not work properly.
[WARNING] Module 'regex' could not be loaded. Some methods may not work properly.
[WARNING] Module 'regex' could not be loaded. Some methods may not work properly.
```

* 2. Run: 

```
from lingpy import *
wl = Wordlist("DOGON.qlc")
wl.tokenize()
wl.output('qlc', filename="DOGON-tokenised")
```

* 3. Inspect DOGON-tokenised.qlc:

```
...
# DATA
ID      DOCULECT        COUNTERPART     CONCEPT TOKENS
#
1       Toro_Tegu       zɔ́ŋɔ̀    (a) fight, squabble
2       Ben_Tey jáy     (a) fight, squabble
...
```

.. note column 5 'TOKENS' is empty.


* 4. Install regex and rerun the code, and the output looks like this:

```
...
ID      DOCULECT        COUNTERPART     CONCEPT TOKENS
#
1       Toro_Tegu       zɔ́ŋɔ̀    (a) fight, squabble     z ɔ́ ŋ ɔ̀
2       Ben_Tey jáy     (a) fight, squabble     j á y
...
```



The solutions are to either --

1. add `regex` to the requirements for lingpy (easiest, but adds a

2. catch this error. The attached patch does this -- it tries to reimport regex if no orthography_profile is defined, and then raises an ImportError. I also move .grapheme_pattern to be non-defined otherwise, as the original python 're' library won't find anything with the pattern \X.


(I've also changed 'trie' to 'tree' in the inline code comments -- the output refers to this as tree not trie, so I thought consistency was good). 