### PR TITLE
enhanced test coverage, refactored alignment evaluation classes

### DIFF
--- a/lingpy/tests/evaluate/__init__.py
+++ b/lingpy/tests/evaluate/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals

--- a/lingpy/tests/evaluate/test_acd.py
+++ b/lingpy/tests/evaluate/test_acd.py
@@ -1,0 +1,30 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from lingpy import LexStat
+from lingpy.tests.util import test_data, WithTempDir
+
+
+class Tests(WithTempDir):
+    def setUp(self):
+        WithTempDir.setUp(self)
+        self.lex = LexStat(test_data('KSL.qlc'))
+
+    def test_bcubes(self):
+        from lingpy.evaluate.acd import bcubes
+
+        res = bcubes(self.lex, test='cogid')
+        self.assertAlmostEquals(res, (1.0, 1.0, 1.0))
+
+    def test_pairs(self):
+        from lingpy.evaluate.acd import pairs
+
+        res = pairs(self.lex, test='cogid')
+        self.assertAlmostEquals(res, (1.0, 1.0, 1.0))
+
+    def test_diff(self):
+        from lingpy.evaluate.acd import diff
+
+        res = diff(self.lex, test='cogid', tofile=False)
+        self.assertAlmostEquals(res, ((1.0, 1.0, 1.0), (1.0, 1.0, 1.0)))
+        diff(self.lex, test='cogid', filename='%s' % self.tmp_path('test_acd'))

--- a/lingpy/tests/evaluate/test_apa.py
+++ b/lingpy/tests/evaluate/test_apa.py
@@ -1,0 +1,39 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from lingpy.align.sca import MSA, PSA
+from lingpy.tests.util import test_data, WithTempDir
+
+
+class Tests(WithTempDir):
+    def test_EvalPSA(self):
+        from lingpy.evaluate.apa import EvalPSA
+
+        obj = EvalPSA(
+            PSA(test_data('harry_potter.psa')),
+            PSA(test_data('harry_potter_misaligned.psa')))
+        obj.c_score()
+        obj.r_score()
+        obj.sp_score()
+        obj.jc_score()
+        obj.diff(filename='%s' % self.tmp_path('test_EvalPSA.diff'))
+
+    def test_EvalMSA(self):
+        from lingpy.evaluate.apa import EvalMSA
+
+        msa = MSA(test_data('harry.msa'))
+        msa2 = MSA(test_data('harryp.msa'))
+
+        for test in [msa, msa2]:
+            obj = EvalMSA(msa, test)
+            for mode in range(1, 5):
+                obj.c_score(mode=mode)
+                if hasattr(obj, 'pic'):
+                    del obj.pic
+            self.assertRaises(ValueError, obj.c_score, 10)
+            res = obj.r_score()
+            if test == msa:
+                self.assertAlmostEquals(res, 1.0)
+            obj.sp_score()
+            obj.jc_score()
+            obj.check_swaps()

--- a/lingpy/tests/test_data/harry_potter.psa
+++ b/lingpy/tests/test_data/harry_potter.psa
@@ -1,0 +1,13 @@
+Harry Potter Testset
+Woldemort in German and Russian
+German.	w	a	l	-	d	e	m	a	r
+Russian	v	-	l	a	d	i	m	i	r
+
+Woldemort in English and Russian
+English	w	o	l	-	d	e	m	o	r	t
+Russian	v	-	l	a	d	i	m	i	r	-
+
+Woldemort in English and German
+English	w	o	l	d	e	m	o	r	t
+German.	w	a	l	d	e	m	a	r	-
+

--- a/lingpy/tests/test_data/harry_potter_misaligned.psa
+++ b/lingpy/tests/test_data/harry_potter_misaligned.psa
@@ -1,0 +1,13 @@
+Harry Potter Testset
+Woldemort in German and Russian
+German.	w	a	l	-	d	e	m	a	r
+Russian	v	-	l	a	d	i	m	i	r
+
+Woldemort in English and Russian
+English	w	o	l	-	d	e	m	o	r	t
+Russian	v	-	l	a	d	i	m	i	r	-
+
+Woldemort in English and German
+English	w	o	-	l	d	-	e	m	o	r	t
+German.	w	a	l	-	d	e	-	m	a	r	-
+

--- a/lingpy/tests/thirdparty/test_cogent.py
+++ b/lingpy/tests/thirdparty/test_cogent.py
@@ -1,18 +1,12 @@
 # *-* coding: utf-8 *-*
-# These lines were automatically added by the 3to2-conversion.
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-# author   : Johann-Mattis List
-# email    : mattis.list@uni-marburg.de
-# created  : 2013-11-20 20:02
-# modified : 2013-11-20 20:02
 """
 Test thirdparty modules.
 """
+from __future__ import unicode_literals, print_function, division
+from unittest import TestCase
+from collections import defaultdict
 
-__author__="Johann-Mattis List"
-__date__="2013-11-20"
+from six import PY3
 
 from lingpy.thirdparty.cogent import LoadTree
 from lingpy.tests.util import test_data
@@ -32,10 +26,69 @@ def test_LoadTree():
             "Xi\u2019an", "Xiamen", "Xianggang", "Xiangtan", "Xining",
             "Yinchuan", "Zhengzhou"])
     
-    for a,b in zip(sorted(tree.taxa), taxa):
+    for a, b in zip(sorted(tree.taxa), taxa):
         assert a == b
     
     tree = LoadTree("((((((((Taiyuan,Pingyao,Huhehaote),((((Xi’an,Xining,Zhengzhou),(Lanzhou,Yinchuan,Wulumuqi)),(((Tianjin,Jinan),Qingdao),Beijing,Haerbin)),(((Guiyang,Kunming),Chengdu,Wuhan),(Nanjing,Hefei)))),(Xiangtan,Changsha)),Nanchang),(Shexian,Tunxi)),((Shanghai,Suzhou,Hangzhou),Wenzhou)),(((Xianggang,Guangzhou),Nanning),(Meixian,Taoyuan))),((((Xiamen,Taibei),Shantou,Haikou),Fuzhou),Jian’ou));")
 
-    for a,b in zip(sorted(tree.taxa), taxa):
+    for a, b in zip(sorted(tree.taxa), taxa):
         assert a == b
+
+
+class TreeTests(TestCase):
+    def test_Tree(self):
+        from lingpy.thirdparty.cogent import TreeNode, TreeError
+
+        tree = TreeNode(
+            Name='a',
+            Children=[
+                TreeNode(Name='b', Children=[TreeNode(Name='c')]),
+                TreeNode(Name='b2'),
+            ])
+        tree.getEdgeNames('b', 'c', False, False)
+        assert tree[0]
+        tree.compareByNames(tree[0])
+        '%s' % tree.copy()
+        assert tree.params == {}
+        if not PY3:
+            tree.makeTreeArray()
+        tree.prune()
+        tree.getDistances()
+        list(tree.traverse_recursive())
+        self.assertEquals(tree.lowestCommonAncestor(['b', 'c']).Name, 'a')
+        self.assertEquals(tree.separation(tree[0]), 1)
+        for before in [True, False]:
+            for after in [True, False]:
+                list(tree.traverse(before, after))
+        assert tree.childGroups()
+        tree[0].childGroups()
+        tree.compareBySubsets(tree.sorted())
+        for p1 in [True, False]:
+            for p2 in [True, False]:
+                tree.asciiArt(p1, p2, defaultdict(lambda: 'a'))
+        self.assertRaises(TreeError, tree.getSubTree, [])
+        tree.get_LCA(tree.getNodeNames()[0])
+        tree.getNewickRecursive()
+
+
+class PhyloNodeTests(TestCase):
+    def test_PhyloNode(self):
+        from lingpy.thirdparty.cogent import PhyloNode
+
+        node = PhyloNode(
+            Length=1,
+            Name='a',
+            Children=[
+                PhyloNode(Length=7, Name='b'),
+                PhyloNode(Length=3, Name='c')])
+        node.scaleBranchLengths()
+        node.tipsWithinDistance(0.5)
+        node.append(PhyloNode(Length=7, Name='d'))
+        node.tipToTipDistances()
+        node.rootAtMidpoint()
+        node.balanced()
+        node.unrooted()
+        if not PY3:
+            node.compareByPartitions(PhyloNode(Name='x'))
+        node.getDistances()
+        node.tipToTipDistances()

--- a/lingpy/thirdparty/cogent/tree.py
+++ b/lingpy/thirdparty/cogent/tree.py
@@ -50,7 +50,7 @@ __maintainer__ = "Gavin Huttley"
 __email__ = "gavin.huttley@anu.edu.au"
 __status__ = "Production"
 
-if sys.version_info[0] > 2:
+if sys.version_info[0] > 2:  # pragma: no cover
     from functools import reduce
 
     def cmp(a, b):
@@ -121,7 +121,7 @@ class TreeNode(object):
         WARNING: Does not currently set the class to the right type.
         """
         return 'Tree("%s")' % self.getNewick()
-    
+
     def __str__(self):
         """Returns Newick-format string representation of tree."""
         return self.getNewick()
@@ -2212,7 +2212,7 @@ class TreeBuilder(object):
         self._used_names = {'edge':-1}
         self._known_edges = {}
         self.TreeNodeClass = constructor
-    
+
     def _unique_name(self, name):
         # Unnamed edges become edge.0, edge.1 edge.2 ...
         # Other duplicates go mouse mouse.2 mouse.3 ...
@@ -2254,6 +2254,7 @@ class TreeBuilder(object):
         self._known_edges[id(node)] = node
         return node
 
+
 def LoadTree(filename=None, treestring=None, tip_names=None, underscore_unmunge=False):
 
     """Constructor for tree.
@@ -2267,7 +2268,6 @@ def LoadTree(filename=None, treestring=None, tip_names=None, underscore_unmunge=
     of the Newick format. Set underscore_unmunge to True to replace underscores
     with spaces in all names read.
     """
-
     if filename:
         assert not (treestring or tip_names)
         # slight modification for easy import of treestrings instead of
@@ -2290,4 +2290,3 @@ def LoadTree(filename=None, treestring=None, tip_names=None, underscore_unmunge=
     else:
         raise TreeError('filename or treestring not specified')
     return tree
- 

--- a/lingpy/util.py
+++ b/lingpy/util.py
@@ -14,6 +14,7 @@ from six import text_type
 import lingpy
 from lingpy.log import get_logger, get_level
 
+
 class TemporaryPath(object):
     def __init__(self, suffix=''):
         fp = NamedTemporaryFile(suffix=suffix)
@@ -164,3 +165,52 @@ def setdefaults(d, **kw):
     """
     for k, v in kw.items():
         d.setdefault(k, v)
+
+
+class cached_property(object):
+
+    """Decorator for read-only properties evaluated only once.
+
+    It can be used to create a cached property like this::
+
+        import random
+
+        # the class containing the property must be a new-style class
+        class MyClass(object):
+            # create property whose value is cached
+            @cached_property()
+            def randint(self):
+                # will only be evaluated once.
+                return random.randint(0, 100)
+
+    The value is cached  in the '_cache' attribute of the object instance that
+    has the property getter method wrapped by this decorator. The '_cache'
+    attribute value is a dictionary which has a key for every property of the
+    object which is wrapped by this decorator. Each entry in the cache is
+    created only when the property is accessed for the first time and is the last
+    computed property value.
+
+    To expire a cached property value manually just do::
+
+        del instance._cache[<property name>]
+
+    inspired by the recipe by Christopher Arndt in the PythonDecoratorLibrary
+    """
+
+    def __call__(self, fget):
+        self.fget = fget
+        self.__doc__ = fget.__doc__
+        self.__name__ = fget.__name__
+        self.__module__ = fget.__module__
+        return self
+
+    def __get__(self, inst, owner):
+        if not hasattr(inst, '_cache'):
+            inst._cache = {}
+        if self.__name__ not in inst._cache:
+            inst._cache[self.__name__] = self.fget(inst)
+        return inst._cache[self.__name__]
+
+
+def identity(x):
+    return x


### PR DESCRIPTION
Other than adding tests, the main change is an attempt to refactor the evaluation classes in `lingpy.evaluate` such that
- instance attributes are not defined outside of the class' `__init__` method,
- result caching is implemented using `lingpy.util.cached_property`, rather than checking for attributes.

In general, I think, it must be forbidden to create instance attributes as side effects of method calls, because this makes testing and reasoning about the code almost impossible. Having a method called `get_xxx` which returns `None`, but creates a couple of instance attributes should be considered an anti-pattern.