### PR TITLE
Refactored QLCParser and subclasses

### DIFF
--- a/lingpy/evaluate/alr.py
+++ b/lingpy/evaluate/alr.py
@@ -1,31 +1,24 @@
-# author   : Johann-Mattis List
-# email    : mattis.list@uni-marburg.de
-# created  : 2013-09-05 18:22
-# modified : 2013-11-12 14:46
 """
 Module provides methods for the evaluation of automatic linguistic reconstruction analyses.
 """
-
-__author__="Johann-Mattis List"
-__date__="2013-11-12"
-
+from __future__ import unicode_literals, division, print_function
 import logging
 
 from ..settings import rcParams
 from ..align.pairwise import edit_dist
-from ..sequence.sound_classes import ipa2tokens,tokens2class
+from ..sequence.sound_classes import ipa2tokens, tokens2class
 from .. import log
+from ..util import setdefaults
 
 
 def mean_edit_distance(
         wordlist,
-        gold = "proto",
-        test = "consensus",
-        ref = "cogid",
-        tokens = True,
-        classes = False,
-        **keywords
-        ):
+        gold="proto",
+        test="consensus",
+        ref="cogid",
+        tokens=True,
+        classes=False,
+        **keywords):
     """
     Function computes the edit distance between gold standard and test set.
 
@@ -48,61 +41,42 @@ def mean_edit_distance(
     This function has an alias ("med"). Calling it will produce the same
     results.
     """
-    defaults = dict(
-            merge_vowels = rcParams['merge_vowels'],
-            model = rcParams['model']
-            )
-    for k in defaults:
-        if k not in keywords:
-            keywords[k] = defaults[k]
-    
+    setdefaults(
+        keywords,
+        merge_vowels=rcParams['merge_vowels'],
+        model=rcParams['model'])
+
     distances = []
-    etd = wordlist.get_etymdict(ref=ref)
-    
-    for key,idxs in etd.items():
-        
+
+    for key, idxs in wordlist.get_etymdict(ref=ref).items():
         # get only valid numbers for index-search
         idx = [idx[0] for idx in idxs if idx != 0][0]
 
-        if log.get_level() <= logging.DEBUG:
-            print(idx,idxs)
-        
-        # get proto and consensus from wordlist
-        proto = wordlist[idx,gold]
-        consensus = wordlist[idx,test]
+        if log.get_level() <= logging.DEBUG:  # pragma: no cover
+            print(idx, idxs)
 
-        if log.get_level() <= logging.DEBUG:
-            print(proto,consensus)
+        # get proto and consensus from wordlist
+        proto = wordlist[idx, gold]
+        consensus = wordlist[idx, test]
+
+        if log.get_level() <= logging.DEBUG:  # pragma: no cover
+            print(proto, consensus)
 
         if tokens or classes:
-            proto = ipa2tokens(proto,**keywords)
-            consensus = ipa2tokens(consensus,**keywords)
+            proto = ipa2tokens(proto, **keywords)
+            consensus = ipa2tokens(consensus, **keywords)
 
             if classes:
-                proto = tokens2class(proto,**keywords)
-                consensus = tokens2class(consensus,**keywords)
-        
-        d = edit_dist(
-                proto,
-                consensus,
-                normalized = False
-                )
-        distances += [d]
+                proto = tokens2class(proto, **keywords)
+                consensus = tokens2class(consensus, **keywords)
+
+        distances.append(edit_dist(proto, consensus, normalized=False))
 
     med = sum(distances) / len(distances)
     log.info("MEAN ED: {0:.2f}".format(med))
     return med
 
 
-def med(
-        wordlist,
-        gold = "proto",
-        test = "consensus",
-        ref = "cogid",
-        tokens = True,
-        classes = False,
-        **keywords
-        ):
+def med(wordlist, **keywords):
     # alias for mean_edit_distance
-    return mean_edit_distance(wordlist,gold,test,ref,tokens,classes,**keywords)
-
+    return mean_edit_distance(wordlist, **keywords)

--- a/lingpy/meaning/basvoc.py
+++ b/lingpy/meaning/basvoc.py
@@ -1,24 +1,15 @@
-# author   : Johann-Mattis List
-# email    : mattis.list@uni-marburg.de
-# created  : 2013-10-11 22:59
-# modified : 2013-10-17 13:05
 """
 Class for the handling of basic vocabulary lists.
 """
+from __future__ import unicode_literals, print_function, division
 
-__author__="Johann-Mattis List"
-__date__="2013-10-17"
-
-from ..settings import rcParams
-import os
-from ..basic.parser import QLCParser
-from six import text_type as str
 import numpy as np
 
+from ..basic.parser import QLCParserWithRowsAndCols
 from .. import util
 
 
-class BasVoc(QLCParser):
+class BasVoc(QLCParserWithRowsAndCols):
     """
     Load a comparative collection of Swadesh lists (concepticon).
     
@@ -78,182 +69,45 @@ class BasVoc(QLCParser):
          ['33', 'give']]
 
     """
-
     def __init__(self, infile=None, col='list', row='key', conf=None):
-        QLCParser.__init__(
+        QLCParserWithRowsAndCols.__init__(
             self,
             infile or util.data_path('swadesh', 'swadesh.qlc'),
+            row,
+            col,
             conf or util.data_path('conf', 'swadesh.rc'))
 
         # get row and key index
-        if not hasattr(self,'_rowidx'):
-            try:
-                rowIdx = self.header[self._alias[row]]
-                colIdx = self.header[self._alias[col]]
-            except:
-                raise ValueError("[!] Could not find row and col in configuration or input file!")
-
-
-            basic_rows = sorted(
-                    set(
-                        [self._data[k][rowIdx] for k in self._data if k != 0 and type(k) == int]
-                        ),
-                    key = lambda x: ('%s' % x).lower()
-                    )
-            basic_cols = sorted(
-                    set(
-                        [self._data[k][colIdx] for k in self._data if k != 0 and type(k) == int]
-                        ),
-                    key = lambda x: x.lower()
-                    )
-            
-            # define rows and cols as attributes of the word list
-            self.rows = basic_rows
-            self.cols = basic_cols
-
-            # define height and width of the word list
-            self.height = len(self.rows)
-            self.width = len(self.cols)
-            
-            # row and column index point to the place where the data of the main
-            # items is stored in the original dictionary
-            self._rowIdx = rowIdx
-            self._colIdx = colIdx
-            self._row_name = self._alias[row]
-            self._col_name = self._alias[col]
-
-            # create a basic array which assigns ids for the entries in a starling
-            # manner. 
-
-            # first, find out, how many items (== synonyms) are there maximally for
-            # each row
-            tmp_dict = {}
-            for key,value in [(k,v) for k,v in self._data.items() if k != 0 and str(k).isnumeric()]:
-                try:
-                    tmp_dict[value[rowIdx]][value[colIdx]] += [key]
-                except KeyError:
-                    try:
-                        tmp_dict[value[rowIdx]][value[colIdx]] = [key]
-                    except KeyError:
-                        tmp_dict[value[rowIdx]] = {}
-                        tmp_dict[value[rowIdx]][value[colIdx]] = [key]
-        
-            # assign the values as _dict-attribute to the dictionary
-            self._dict = tmp_dict
-
-            # create the array by counting the maximal number of occurrences, store
-            # the row names separately in a dictionary
-            tmp_list = []
-            row_dict = {}
-            
-            count = 0
-            for k,d in self._dict.items():
-
-                row_dict[k] = []
-
-                # get maximal amount of "synonyms"
-                m = max(
-                        [len(x) for x in d.values()]
-                        )
-
-                for i in range(m):
-                    tmp = []
-                    for j in range(self.width):
-                        try:
-                            tmp.append(
-                                    d[self.cols[j]][i]
-                                    )
-                        except:
-                            tmp.append(0)
-                    row_dict[k] += [count]
-                    count += 1
-                    tmp_list += [tmp]
-
-            # create the array 
-            self._array = np.array(tmp_list)
-            self._idx = row_dict
-
+        if not hasattr(self, '_rowidx'):
             # add indices to alias dictionary for swadesh lists
-            for i,col in enumerate(self.cols):
-                self._meta[col] = self._array[np.nonzero(self._array[:,i]),i][0]
-                
-        # define a cache dictionary for stored data for quick access
-        self._cache = {}
-        
-    def __getitem__(self,idx):
+            for i, col in enumerate(self.cols):
+                self._meta[col] = self._array[np.nonzero(self._array[:, i]), i][0]
+
+    def __getitem__(self, idx):
         """
         Method allows quick access to the data by passing the integer key.
         """
         try:
-            return self._cache[idx]
-        except:
+            return self._get_cached(idx)
+        except KeyError:
             try:
-                # return full data entry as list
-                out = self._data[idx]
-                self._cache[idx] = out
-                return out
+                if isinstance(idx[1], (tuple, list)):
+                    self._cache[idx] = [
+                        self._data[idx[0]][self._header[self._alias[i]]] for i in idx[1]]
+                    return self._cache[idx]
+                # return data entry with specified key word
+                return self._data[idx[0]][self._header[self._alias[idx[1]]]]
             except:
                 try:
-                    if type(idx[1]) in [tuple,list]:
-                        out = [self._data[idx[0]][self._header[self._alias[i]]] for i in idx[1]]
-                        self._cache[idx] = out
-                        return out
-                    else:
-                        # return data entry with specified key word
-                        out = self._data[idx[0]][self._header[self._alias[idx[1]]]]
-                        return out
+                    if len(idx) == 2:
+                        return [self._data[i][self._header[idx[1]]]
+                                for i in self._meta[idx[0]]]
+                    return [[self._data[i][self._header[x]]
+                             for x in idx[1:]] for i in self._meta[idx[0]]]
                 except:
-                    try:
-                        if len(idx) == 2:
-                            return [self._data[i][self._header[idx[1]]] for i in self._meta[idx[0]]]
-                        else:
-                            return [[self._data[i][self._header[x]] for x in idx[1:]] for i in self._meta[idx[0]]]
-                    except:
-                        raise KeyError("[ERROR] Key {0} cannot be interpreted.")
+                    raise KeyError("[ERROR] Key {0} cannot be interpreted.")
 
-    def __getattr__(
-            self,
-            attr
-            ):
-        """
-        Define how attributes are overloaded.
-        """
-        try:
-            # get the right name
-            nattr = self._alias[attr]
-
-            if nattr == self._row_name:
-                return self.rows
-            elif nattr == self._col_name:
-                return self.cols
-            elif nattr in self._header:
-                return self.get_entries(nattr)
-            else:
-                raise AttributeError("%r object has no attribute %r" %
-                        (self.__class__,attr))
-        except:
-            try:
-                return self._meta[attr] #return #return self._lists[attr]
-            except:
-                raise AttributeError("%r object has no attribute %r" %
-                        (self.__class__,attr))
-
-    def _clean_cache(self):
-
-        """
-        Function cleans the cache.
-        """
-        del self._cache
-        self._cache = {}
-
-    
-    def get_dict(
-            self,
-            col = '',
-            row = '',
-            entry = '',
-            **keywords
-            ):
+    def get_dict(self, col='', row='', entry='', **keywords):
         """
         Return a dictionary representation for a given concept list.
 
@@ -272,7 +126,6 @@ class BasVoc(QLCParser):
             A dictionary with the unique IDs as key and the specified entry as
             value.
         """
-
         if row and not col:
             try:
                 return self._cache[row,entry]
@@ -355,11 +208,8 @@ class BasVoc(QLCParser):
 
 
             print("[!] Neither rows nor columns are selected!")
-    def get_list(
-            self,
-            swadlist,
-            *entries
-            ):
+
+    def get_list(self, swadlist, *entries):
         """
         Return a given concept list with the specified entries.
 
@@ -443,4 +293,3 @@ class BasVoc(QLCParser):
                     ]
         else:
             return [l[self.header[entries[0]]] for l in listA if l[self.header['key']] in listB]
-

--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -1,14 +1,43 @@
 import os
 from unittest import TestCase
+from operator import itemgetter
+from collections import defaultdict
+
+from mock import patch, Mock
 
 from lingpy.tests.util import test_data
+from lingpy.basic.parser import QLCParser, QLCParserWithRowsAndCols
 
 
 class TestParser(TestCase):
     def setUp(self):
-        from lingpy.basic.parser import QLCParser
-
         self.parser = QLCParser(test_data('KSL.qlc'))
+
+    def test_init(self):
+        p = QLCParser({0: ['a']})
+        QLCParser(p)
+        self.assertRaises(IOError, QLCParser, 'not-extisting-file')
+        self.assertRaises(TypeError, QLCParser, None)
+        self.assertRaises(ValueError, QLCParserWithRowsAndCols, {0: ['a']}, 'x', 'y', {})
+
+    def test__tokenize(self):
+        self.parser._tokenize(target='ttokens', source='gloss')
+
+    def test_getitem(self):
+        key = list(self.parser._data.keys())[0]
+        self.assertEquals(self.parser[key], self.parser._data[key])
+        assert self.parser[key, 'cogid']
+        self.assertRaises(KeyError, itemgetter(None), self.parser)
+        self.parser._meta['aaa'] = 3
+        assert self.parser['aaa']
+
+    def test_get_entries(self):
+        parser = QLCParserWithRowsAndCols(test_data('KSL.qlc'), 'gloss', 'cogid', {})
+        assert parser.get_entries('cogid')
+
+    def test_getattr(self):
+        parser = QLCParserWithRowsAndCols(test_data('KSL.qlc'), 'gloss', 'cogid', {})
+        assert parser.cogid
 
     def test_cache(self):
         from lingpy.basic.parser import QLCParser
@@ -31,13 +60,28 @@ class TestParser(TestCase):
         assert len(self.parser)
 
     def test_add_entries(self):
-        # shouldn't this raise an exception?
-        self.assertRaises(ValueError, self.parser.add_entries, '', 'taxon',
-            lambda t: t.lower())
+        self.assertRaises(
+            ValueError, self.parser.add_entries, '', 'taxon', lambda t: t.lower())
             
-        # shouldn't this call work?
-        #self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower(), override=True)
-
-        self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower())
-
+        self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower(), override=True)
         assert 'ltaxon' in self.parser.entries
+
+        with patch('lingpy.basic.parser.input', Mock(return_value='y')):
+            self.parser.add_entries('ltaxon', 'taxon', lambda t: t.lower())
+
+        self.parser.add_entries('tg', 'taxon,gloss', lambda v, id_: ''.join(v))
+        self.assertRaises(
+            ValueError, self.parser.add_entries, 'll', 'taxon,gloss', lambda x, y: 1 / 0)
+        self.parser.add_entries('ti', defaultdict(int), lambda i: i + 1)
+        assert 'ti' in self.parser.entries
+        self.parser.add_entries('tg', defaultdict(int), lambda i: i + 1, override=True)
+        self.parser.add_entries('tg', 'taxon,gloss', lambda v, id_: 'abc', override=True)
+
+    def test__cache(self):
+        parser = QLCParserWithRowsAndCols(test_data('KSL.qlc'), 'gloss', 'cogid', {})
+        idx = list(parser._data.keys())[0]
+        parser._get_cached(idx)
+        parser._get_cached(idx)
+        parser._clean_cache()
+        parser._data.pop(idx)
+        self.assertRaises(KeyError, parser._get_cached, idx)

--- a/lingpy/tests/evaluate/test_alr.py
+++ b/lingpy/tests/evaluate/test_alr.py
@@ -1,0 +1,17 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from lingpy import Wordlist
+from lingpy.tests.util import test_data, WithTempDir
+
+
+class Tests(WithTempDir):
+    def setUp(self):
+        WithTempDir.setUp(self)
+        self.wl = Wordlist(test_data('KSL.qlc'))
+
+    def test_med(self):
+        from lingpy.evaluate.alr import med
+
+        self.assertAlmostEquals(
+            med(self.wl, gold='gloss', test='gloss', classes=True), 0.0)

--- a/lingpy/tests/meaning/test_glosses.py
+++ b/lingpy/tests/meaning/test_glosses.py
@@ -2,8 +2,8 @@ from lingpy.tests.util import test_data
 from lingpy.read.csv import *
 from lingpy.meaning.glosses import parse_gloss, compare_conceptlists
 
-def test_parse_gloss():
 
+def test_parse_gloss():
     data = csv2list(test_data('Ringe-2002-421.tsv'))[1:]
     target_list = [x[0] for x in csv2list(test_data('target_list_ringe.tsv'))]
     for line,target in zip(data,target_list):
@@ -13,8 +13,8 @@ def test_parse_gloss():
             print(datum,'=>',','.join([x for x in [a,b,c,d,e,f,g,''.join(h),i]]),'\t',a)
             assert a == target
 
-def test_conceptlists():
 
+def test_conceptlists():
     comparison = compare_conceptlists(test_data('listA.tsv'), test_data('listB.tsv'))
 
 
@@ -26,4 +26,3 @@ if __name__ == '__main__':
     
     #for i,line in enumerate(sorted(out, key=lambda x:int(x[-1]))):
     #    print(i+1,line[4],line[0],line[1],line[2],line[3])
-


### PR DESCRIPTION
This PR refactors `QLCParser` and derived classes
- moving code shared between `Wordlist` and `BasVoc` into an intermediate class `QLCParserWithRowsAndCols`,
- moving code which makes use of attributes not initialized in `QLCParser` out of `QLCParser`.

It also simplifies `_add_entries` significantly by wrapping the call to the value converter function in a small helper.

Last but not least, it adds tests for most of the functionality in `lingpy.basic.parser`.