### PR TITLE
Rollback corrdist refactoring

### DIFF
--- a/lingpy/evaluate/alr.py
+++ b/lingpy/evaluate/alr.py
@@ -1,31 +1,24 @@
-# author   : Johann-Mattis List
-# email    : mattis.list@uni-marburg.de
-# created  : 2013-09-05 18:22
-# modified : 2013-11-12 14:46
 """
 Module provides methods for the evaluation of automatic linguistic reconstruction analyses.
 """
-
-__author__="Johann-Mattis List"
-__date__="2013-11-12"
-
+from __future__ import unicode_literals, division, print_function
 import logging
 
 from ..settings import rcParams
 from ..align.pairwise import edit_dist
-from ..sequence.sound_classes import ipa2tokens,tokens2class
+from ..sequence.sound_classes import ipa2tokens, tokens2class
 from .. import log
+from ..util import setdefaults
 
 
 def mean_edit_distance(
         wordlist,
-        gold = "proto",
-        test = "consensus",
-        ref = "cogid",
-        tokens = True,
-        classes = False,
-        **keywords
-        ):
+        gold="proto",
+        test="consensus",
+        ref="cogid",
+        tokens=True,
+        classes=False,
+        **keywords):
     """
     Function computes the edit distance between gold standard and test set.
 
@@ -48,61 +41,42 @@ def mean_edit_distance(
     This function has an alias ("med"). Calling it will produce the same
     results.
     """
-    defaults = dict(
-            merge_vowels = rcParams['merge_vowels'],
-            model = rcParams['model']
-            )
-    for k in defaults:
-        if k not in keywords:
-            keywords[k] = defaults[k]
-    
+    setdefaults(
+        keywords,
+        merge_vowels=rcParams['merge_vowels'],
+        model=rcParams['model'])
+
     distances = []
-    etd = wordlist.get_etymdict(ref=ref)
-    
-    for key,idxs in etd.items():
-        
+
+    for key, idxs in wordlist.get_etymdict(ref=ref).items():
         # get only valid numbers for index-search
         idx = [idx[0] for idx in idxs if idx != 0][0]
 
-        if log.get_level() <= logging.DEBUG:
-            print(idx,idxs)
-        
-        # get proto and consensus from wordlist
-        proto = wordlist[idx,gold]
-        consensus = wordlist[idx,test]
+        if log.get_level() <= logging.DEBUG:  # pragma: no cover
+            print(idx, idxs)
 
-        if log.get_level() <= logging.DEBUG:
-            print(proto,consensus)
+        # get proto and consensus from wordlist
+        proto = wordlist[idx, gold]
+        consensus = wordlist[idx, test]
+
+        if log.get_level() <= logging.DEBUG:  # pragma: no cover
+            print(proto, consensus)
 
         if tokens or classes:
-            proto = ipa2tokens(proto,**keywords)
-            consensus = ipa2tokens(consensus,**keywords)
+            proto = ipa2tokens(proto, **keywords)
+            consensus = ipa2tokens(consensus, **keywords)
 
             if classes:
-                proto = tokens2class(proto,**keywords)
-                consensus = tokens2class(consensus,**keywords)
-        
-        d = edit_dist(
-                proto,
-                consensus,
-                normalized = False
-                )
-        distances += [d]
+                proto = tokens2class(proto, **keywords)
+                consensus = tokens2class(consensus, **keywords)
+
+        distances.append(edit_dist(proto, consensus, normalized=False))
 
     med = sum(distances) / len(distances)
     log.info("MEAN ED: {0:.2f}".format(med))
     return med
 
 
-def med(
-        wordlist,
-        gold = "proto",
-        test = "consensus",
-        ref = "cogid",
-        tokens = True,
-        classes = False,
-        **keywords
-        ):
+def med(wordlist, **keywords):
     # alias for mean_edit_distance
-    return mean_edit_distance(wordlist,gold,test,ref,tokens,classes,**keywords)
-
+    return mean_edit_distance(wordlist, **keywords)

--- a/lingpy/tests/evaluate/test_alr.py
+++ b/lingpy/tests/evaluate/test_alr.py
@@ -1,0 +1,17 @@
+# coding: utf8
+from __future__ import unicode_literals
+
+from lingpy import Wordlist
+from lingpy.tests.util import test_data, WithTempDir
+
+
+class Tests(WithTempDir):
+    def setUp(self):
+        WithTempDir.setUp(self)
+        self.wl = Wordlist(test_data('KSL.qlc'))
+
+    def test_med(self):
+        from lingpy.evaluate.alr import med
+
+        self.assertAlmostEquals(
+            med(self.wl, gold='gloss', test='gloss', classes=True), 0.0)


### PR DESCRIPTION
As reported in #169 the refactoring of the corrdist computations in https://github.com/lingpy/lingpy/commit/ec76e60eb83c8bac80051b27afc2850943a672c9 broke correctness. This PR rolls back these changes.

@xrotwang This issue also highlights, that we should not mix code-style fixes with changes of program logic.