### PR TITLE
Cleaning up tests

### DIFF
--- a/lingpy/tests/sequence/test_sound_classes.py
+++ b/lingpy/tests/sequence/test_sound_classes.py
@@ -57,7 +57,6 @@ def test_ipa2tokens():
 
     tokens = csv2list(test_data('test_tokenization_nasals.tsv'))
     for a,b in tokens:
-        print(tks)
         tks = ' '.join(ipa2tokens(a, merge_vowels=True, merge_geminates=True,
             expand_nasals=True, semi_diacritics='h'))
         assert tks == b
@@ -144,10 +143,7 @@ def test_trigrams():
     assert trigrams('ab')[0] == ('#', '#' ,'a') and trigrams('ab')[-1] == ('b','$', '$')
 
 def test_fourgrams():
-    
     f = fourgrams('ab')
-    print(f)
-
     assert f[0] == ('#','#','#','a')
     assert f[-1] == ('b','$','$','$')
 

--- a/lingpy/tests/test_log.py
+++ b/lingpy/tests/test_log.py
@@ -2,19 +2,23 @@ from __future__ import unicode_literals
 
 from lingpy.tests.util import WithTempDir
 
+from lingpy import log
+
 
 class LogTest(WithTempDir):
-    def test_new_config(self):
-        from lingpy.log import get_logger
+    def tearDown(self):
+        # Reset the global _logger to make sure, it's recreated with appropriate config
+        # when the other tests are run.
+        log._logger = None
+        WithTempDir.tearDown(self)
 
-        log = get_logger(config_dir=self.tmp, test=True)
-        self.assertTrue(hasattr(log, 'info'))
+    def test_new_config(self):
+        l = log.get_logger(config_dir=self.tmp, test=True)
+        self.assertTrue(hasattr(l, 'info'))
 
     def test_default_config(self):
-        from lingpy.log import get_logger
-
-        log = get_logger(config_dir=self.tmp, force_default_config=True)
-        self.assertTrue(hasattr(log, 'info'))
+        l = log.get_logger(config_dir=self.tmp, force_default_config=True)
+        self.assertTrue(hasattr(l, 'info'))
 
     def test_convenience(self):
         from lingpy.log import info, warn, debug, error, deprecated, missing_module, file_written

--- a/lingpy/tests/test_util.py
+++ b/lingpy/tests/test_util.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from .util import WithTempDir
-from .. import util
+from lingpy.tests.util import WithTempDir
+from lingpy import util
 
 
 class Test(WithTempDir):
@@ -10,16 +10,18 @@ class Test(WithTempDir):
             for i in range(n):
                 yield 'line%s' % i
 
-        util.write_text_file('test', 'test')
-        self.assertEqual(util.read_text_file('test'), 'test')
+        path = self.tmp_path('test')
+        util.write_text_file(path, 'test')
+        self.assertEqual(util.read_text_file(path), 'test')
 
-        util.write_text_file('test', ['line1', 'line2'])
-        self.assertEqual(len(util.read_text_file('test', lines=True)), 2)
+        util.write_text_file(path, ['line1', 'line2'])
+        self.assertEqual(len(util.read_text_file(path, lines=True)), 2)
 
-        util.write_text_file('test', lines_generator(5))
-        self.assertEqual(len(util.read_text_file('test', lines=True)), 5)
+        util.write_text_file(path, lines_generator(5))
+        self.assertEqual(len(util.read_text_file(path, lines=True)), 5)
 
     def test_TextFile(self):
-        with util.TextFile('test') as fp:
+        path = self.tmp_path('test')
+        with util.TextFile(path) as fp:
             fp.writelines(['line1\n', 'line2\n'])
-        self.assertEqual(len(util.read_text_file('test', lines=True)), 2)
+        self.assertEqual(len(util.read_text_file(path, lines=True)), 2)

--- a/lingpy/util.py
+++ b/lingpy/util.py
@@ -14,7 +14,7 @@ from six import text_type, PY3
 from six.moves import input
 
 import lingpy
-from lingpy.log import get_logger, get_level, file_written
+from lingpy.log import get_level, file_written
 from lingpy.settings import rcParams
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist =
 [testenv]
 commands =
     python setup.py develop
-    python setup.py nosetests --with-coverage --cover-package=lingpy --cover-erase
-deps = 
+    nosetests --with-coverage --cover-package=lingpy --cover-erase
+deps =
+    mock==1.0
     nosexcover
 
 [testenv:py34]


### PR DESCRIPTION
Closes #194, addresses #200. There is still one test where a file
`lingpy-<date>.qlc` is written. The fact that the exact place is hard
to find highlights the necessity to document side effects like file IO
more thoroughly.

Untracked files:
    lingpy-2016-03-07.qlc