### PR TITLE
misc refactoring

### DIFF
--- a/lingpy/align/_align/confidence.py
+++ b/lingpy/align/_align/confidence.py
@@ -5,7 +5,7 @@ import cgi
 
 from lingpy.sequence.sound_classes import class2tokens, token2class
 from lingpy.settings import rcParams
-from lingpy.util import join
+from lingpy.util import charstring, dotjoin
 
 
 def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
@@ -71,7 +71,7 @@ def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
 
                 # get the char
                 if num != '-':
-                    charA = join('.', taxa[i], msa['alignment'][i][j], num.split('.')[2])
+                    charA = dotjoin(taxa[i], msa['alignment'][i][j], num.split('.')[2])
                     chars += [charA]
                     try:
                         occs[charA] += [concept]
@@ -87,11 +87,8 @@ def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
                         else:
                             if numB != '-' and num != '-':
                                 # get the second char
-                                charB = join(
-                                    '.',
-                                    taxa[k],
-                                    msa['alignment'][k][j],
-                                    numB.split('.')[2])
+                                charB = dotjoin(
+                                    taxa[k], msa['alignment'][k][j], numB.split('.')[2])
                                 try:
                                     corrs[charA][charB] += 1
                                 except:
@@ -102,10 +99,10 @@ def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
 
                             gaps = False
                             if num == '-' and numB != '-':
-                                numA = str(idx) + '.X.-'
+                                numA = charstring(idx)
                                 gaps = True
                             elif numB == '-' and num != '-':
-                                numB = str(alms.taxa.index(taxa[k])) + '.X.-'
+                                numB = charstring(alms.taxa.index(taxa[k]))
                                 numA = num
                                 gaps = True
                             else:
@@ -187,13 +184,12 @@ def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
                 tmp += '<td class="display" rowspan={0}>'.format(spans[a])
                 tmp += a + '</td>'
                 tmp += '<td class="display" onclick="show({0});"><span '.format(
-                    "'" + '.'.join([a, b, c]) + "'")
+                    "'" + dotjoin(a, b, c) + "'")
                 tmp += 'class="char {0}">' + b + '</span></td>'
                 tmp += '<td class="display">'
                 tmp += c + '</td>'
                 tmp += '<td class="display">' + str(d) + '</td>'
-                tmp += '<td class="display">' + str(len(occs['.'.join([a, b, c])])) + \
-                       '</td>'
+                tmp += '<td class="display">' + str(len(occs[dotjoin(a, b, c)])) + '</td>'
                 tmp += '</tr>'
                 t = 'dolgo_' + token2class(b, rcParams['dolgo'])
 
@@ -211,13 +207,11 @@ def get_confidence(alms, scorer, ref='lexstatid', gap_weight=1):
             elif counter > 0:
                 tmp = '<tr class="display">'
                 tmp += '<td class="display" onclick="show({0});"><span '.format(
-                    "'" + '.'.join([a, b, c]) + "'")
+                    "'" + dotjoin(a, b, c) + "'")
                 tmp += 'class="char {0}">' + b + '</span></td>'
-
                 tmp += '<td class="display">' + c + '</td>'
                 tmp += '<td class="display">' + str(d) + '</td>'
-                tmp += '<td class="display">' + str(len(occs['.'.join([a, b, c])])) + \
-                       '</td>'
+                tmp += '<td class="display">' + str(len(occs[dotjoin(a, b, c)])) + '</td>'
                 tmp += '</tr>'
 
                 t = 'dolgo_' + token2class(b, rcParams['dolgo'])
@@ -283,7 +277,7 @@ def get_correspondences(alms, ref='lexstatid'):
 
                 # get the char
                 if num != '-':
-                    charA = join('.', taxa[i], msa['alignment'][i][j], num.split('.')[2])
+                    charA = dotjoin(taxa[i], msa['alignment'][i][j], num.split('.')[2])
                     chars += [charA]
                     try:
                         occs[charA] += [concept]
@@ -299,8 +293,7 @@ def get_correspondences(alms, ref='lexstatid'):
                         else:
                             if numB != '-' and num != '-':
                                 # get the second char
-                                charB = join(
-                                    '.',
+                                charB = dotjoin(
                                     taxa[k],
                                     msa['alignment'][k][j],
                                     numB.split('.')[2])

--- a/lingpy/align/multiple.py
+++ b/lingpy/align/multiple.py
@@ -19,7 +19,7 @@ from lingpy.sequence.sound_classes import (
 )
 from lingpy.settings import rcParams
 from lingpy import log
-from lingpy.util import setdefaults, identity
+from lingpy.util import setdefaults, identity, dotjoin
 
 
 class Multiple(object):
@@ -63,8 +63,7 @@ class Multiple(object):
         self.numbers = []
         if self.tokens:
             for i, tokens in enumerate(self.tokens):
-                self.numbers.append(
-                    [str(i + 1) + '.' + str(j + 1) for j in range(len(tokens))])
+                self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
         else:
             # create a numerical representation of all sequences which reflects the
             # order of both their position and the position of their tokens. Before
@@ -74,8 +73,7 @@ class Multiple(object):
                 # check for pre-tokenized strings
                 tokens = ipa2tokens(seq, **kw)
                 self.tokens.append(tokens)
-                self.numbers.append(
-                    [str(i + 1) + '.' + str(j + 1) for j in range(len(tokens))])
+                self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
 
         self.uniseqs = defaultdict(list)
         self.unique_seqs = kw["unique_seqs"]
@@ -217,16 +215,15 @@ class Multiple(object):
 
         # add the classes
         self._classes = [self.classes[key] for key in keys]
-        self._numbers = [[str(i + 1) + '.' + str(j + 1) for j in
+        self._numbers = [[dotjoin(i + 1, j + 1) for j in
                           range(len(self._classes[i]))] for i in range(self.height)]
 
         # create an index which allows to quickly interchange between classes
         # and given sequences (trivial without sequence uniqueness
         if self.unique_seqs:
-            self.int2ext = dict(
-                [(i, indices[tuple(self._classes[i])]) for i in range(len(keys))])
+            self.int2ext = {i: indices[tuple(self._classes[i])] for i in range(len(keys))}
         else:
-            self.int2ext = dict([(i, [i]) for i in range(len(keys))])
+            self.int2ext = {i: [i] for i in range(len(keys))}
 
         # -> # create external to internal in order to allow for a quick switching
         # -> # of the vals
@@ -454,9 +451,7 @@ class Multiple(object):
         Create the guide tree using either the UPGMA or the Neighbor-Joining
         algorithm.
         """
-        # create the clusters
-        clusters = dict(
-            [(i[0], [i[1]]) for i in zip(range(self.height), range(self.height))])
+        clusters = {i[0]: [i[1]] for i in zip(range(self.height), range(self.height))}
 
         # create the tree matrix
         self.tree_matrix = []
@@ -697,7 +692,7 @@ class Multiple(object):
                 numbers = []
                 for num in line:
                     try:
-                        numbers.append(str(j + 1) + '.' + num.split('.')[1])
+                        numbers.append(dotjoin(j + 1, num.split('.')[1]))
                     except:
                         numbers.append('X')
                 self.alm_matrix[j] = [self._get(num, 'tokens') for num in numbers]
@@ -1312,8 +1307,7 @@ class Multiple(object):
             return
 
         # create the clusters
-        clusters = dict(
-            [(i[0], [i[1]]) for i in zip(range(self.height), range(self.height))])
+        clusters = {i[0]: [i[1]] for i in zip(range(self.height), range(self.height))}
 
         cluster._flat_upgma(clusters, self.matrix, threshold)
         self._iter(
@@ -1640,7 +1634,7 @@ class Multiple(object):
                             for m in tok:
                                 try:
                                     alm.append(self._get(
-                                        str(idx + 1) + '.' + m.split('.')[1], 'tokens'))
+                                        dotjoin(idx + 1, m.split('.')[1]), 'tokens'))
                                 except:
                                     alm.append('-')
 

--- a/lingpy/basic/parser.py
+++ b/lingpy/basic/parser.py
@@ -9,12 +9,12 @@ from collections import defaultdict
 
 from six import text_type as str
 from six import string_types
-from six.moves import input
 
 from lingpy.settings import rcParams
 from lingpy.read.qlc import read_qlc
 from lingpy import cache
 from lingpy import util
+from lingpy.util import confirm
 from lingpy import log
 
 
@@ -236,8 +236,7 @@ class QLCParser(object):
             source,
             function,
             override=False,
-            **keywords
-    ):
+            **keywords):
         """
         Add new entry-types to the word list by modifying given ones.
 
@@ -299,10 +298,9 @@ class QLCParser(object):
 
         # check whether the stuff is already there
         if entry in self._header and not override:
-            answer = input(
-                "[?] Column <{entry}> already exists, do you want to override? (y/n) "
-                .format(entry=entry))
-            if answer.lower() in ['y', 'yes', 'j']:
+            if confirm(
+                "Column <{entry}> already exists, do you want to override?".format(
+                    entry=entry)):
                 keywords['override'] = True
                 return self.add_entries(entry, source, function, **keywords)
             return  # pragma: no cover

--- a/lingpy/compare/lexstat.py
+++ b/lingpy/compare/lexstat.py
@@ -24,6 +24,7 @@ from lingpy.algorithm import calign
 from lingpy.algorithm import talign
 from lingpy.algorithm import misc
 from lingpy import util
+from lingpy.util import charstring
 from lingpy import log
 
 
@@ -45,10 +46,6 @@ def _check_tokens(key_and_tokens):
                         line[sonars.index('0')]), line)
             except ValueError or IndexError:
                 yield (key, "sound-class conversion failed", line)
-
-
-def charstring(id_, char='X', cls='-'):
-    return '{0}.{1}.{2}'.format(id_, char, cls)
 
 
 def char_from_charstring(cstring):
@@ -164,7 +161,7 @@ class LexStat(Wordlist):
             self.model = kw['model']
 
         # set the lexstat stamp
-        self._stamp = "# Created using the LexStat class of LingPy-2.0\n"
+        self._stamp = "# Created using the LexStat class of {0}\n".format(util.PROG)
 
         # initialize the wordlist
         Wordlist.__init__(self, filename)
@@ -241,7 +238,7 @@ class LexStat(Wordlist):
         # add information regarding vowels in the data based on the
         # transformation, which is important for the calculation of the
         # v-scale in lexstat.get_scorer
-        if not 'vowels' in self._meta:
+        if 'vowels' not in self._meta:
             self._meta['vowels'] = ' '.join(sorted(set([self._transform[v] for v
                 in 'XYZT_']))) if hasattr(self, '_transform') else 'VT_'
 
@@ -273,8 +270,8 @@ class LexStat(Wordlist):
                 raise ValueError("Your input data does not contain any entries!")
             self.bad_chars = [char for char in self.chars if char[2] == '0']
             if len(self.bad_chars) / len(self.chars) > rcParams['lexstat_bad_chars_limit']:
-                raise ValueError("{0:.0f}% of the unique characters in your word list are not recognized by LingPy. You should re-load with check=True!".format(
-                        100 * len(self.bad_chars) / len(self.chars)))
+                raise ValueError("{0:.0f}% of the unique characters in your word list are not recognized by {1}. You should re-load with check=True!".format(
+                    100 * len(self.bad_chars) / len(self.chars), util.PROG))
 
         if not hasattr(self, "scorer"):
             self._meta['scorer'] = {}

--- a/lingpy/compare/lexstat.py
+++ b/lingpy/compare/lexstat.py
@@ -1,31 +1,30 @@
 # *-* coding: utf-8 *-*
 from __future__ import print_function, division, unicode_literals
 import random
-from itertools import combinations_with_replacement, product, combinations
+from itertools import product
 
 from collections import Counter, defaultdict
 from math import factorial
 from copy import copy
 
-# thirdparty
 from six import text_type
 from six import string_types
 import numpy as np
 
-# lingpy-modules
-from ..settings import rcParams
-from ..sequence.sound_classes import (
-    ipa2tokens, tokens2class, prosodic_string, prosodic_weights, class2tokens)
-from ..sequence.generate import MCPhon
-from ..basic import Wordlist
-from ..align.pairwise import turchin, edit_dist
-from ..convert.strings import scorer2str
-from ..algorithm import clustering
-from ..algorithm import calign
-from ..algorithm import talign
-from ..algorithm import misc
-from .. import util
-from .. import log
+from lingpy.settings import rcParams
+from lingpy.sequence.sound_classes import (
+    ipa2tokens, tokens2class, prosodic_string, prosodic_weights, class2tokens,
+)
+from lingpy.sequence.generate import MCPhon
+from lingpy.basic import Wordlist
+from lingpy.align.pairwise import turchin, edit_dist
+from lingpy.convert.strings import scorer2str
+from lingpy.algorithm import clustering
+from lingpy.algorithm import calign
+from lingpy.algorithm import talign
+from lingpy.algorithm import misc
+from lingpy import util
+from lingpy import log
 
 
 def _check_tokens(key_and_tokens):
@@ -47,6 +46,7 @@ def _check_tokens(key_and_tokens):
             except ValueError or IndexError:
                 yield (key, "sound-class conversion failed", line)
 
+
 def charstring(id_, char='X', cls='-'):
     return '{0}.{1}.{2}'.format(id_, char, cls)
 
@@ -64,8 +64,7 @@ def char_from_charstring(cstring):
 
 def get_score_dict(chars, model):
     matrix = [[0.0 for i in chars] for j in chars]
-    for (i, charA), (j, charB) in combinations_with_replacement(
-            enumerate(chars), r=2):
+    for (i, charA), (j, charB) in util.multicombinations2(enumerate(chars)):
         matrix[i][j] = model(char_from_charstring(charA), char_from_charstring(charB))
         if i < j:
             matrix[j][i] = matrix[i][j]
@@ -276,7 +275,6 @@ class LexStat(Wordlist):
             if len(self.bad_chars) / len(self.chars) > rcParams['lexstat_bad_chars_limit']:
                 raise ValueError("{0:.0f}% of the unique characters in your word list are not recognized by LingPy. You should re-load with check=True!".format(
                         100 * len(self.bad_chars) / len(self.chars)))
-            
 
         if not hasattr(self, "scorer"):
             self._meta['scorer'] = {}
@@ -299,8 +297,7 @@ class LexStat(Wordlist):
         # make the language pairs
         if not hasattr(self, "pairs"):
             self.pairs = {}
-            for (i, taxonA), (j, taxonB) in combinations_with_replacement(
-                    enumerate(self.taxa), r=2):
+            for (i, taxonA), (j, taxonB) in util.multicombinations2(enumerate(self.taxa)):
                 self.pairs[taxonA, taxonB] = []
                 dictA = self.get_dict(col=taxonA)
                 dictB = self.get_dict(col=taxonB)
@@ -367,7 +364,7 @@ class LexStat(Wordlist):
         list (Swadesh list).
         """
         self.subsets = {}
-        for tA, tB in combinations_with_replacement(self.taxa, r=2):
+        for tA, tB in util.multicombinations2(self.taxa):
             self.subsets[tA, tB] = [
                 pair for pair in self.pairs[tA, tB] if self[pair, ref][0] in sublist]
 
@@ -403,8 +400,7 @@ class LexStat(Wordlist):
 
         tasks = factorial(len(self.taxa) + 1) / 2 / factorial(len(self.taxa) - 1)
         with util.ProgressBar('CORRESPONDENCE CALCULATION', tasks) as progress:
-            for (i, tA), (j, tB) in combinations_with_replacement(
-                    enumerate(self.taxa), r=2):
+            for (i, tA), (j, tB) in util.multicombinations2(enumerate(self.taxa)):
                 progress.update()
                 log.info("Calculating alignments for pair {0} / {1}.".format(tA, tB))
 
@@ -506,8 +502,7 @@ class LexStat(Wordlist):
                              zip(cls, [self._transform[pr] for pr in pros[taxon][-1]])])
 
             with util.ProgressBar('RANDOM CORRESPONDENCE CALCULATION', tasks) as progress:
-                for (i, tA), (j, tB) in combinations_with_replacement(
-                        enumerate(self.taxa), r=2):
+                for (i, tA), (j, tB) in util.multicombinations2(enumerate(self.taxa)):
                     progress.update()
                     log.info(
                         "Calculating random alignments for pair {0} / {1}.".format(tA, tB)
@@ -545,8 +540,7 @@ class LexStat(Wordlist):
         else:
             tasks = factorial(len(self.taxa) + 1) / 2 / factorial(len(self.taxa) - 1)
             with util.ProgressBar('RANDOM CORRESPONDENCE CALCULATION', tasks) as progress:
-                for (i, tA), (j, tB) in combinations_with_replacement(
-                        enumerate(self.taxa), r=2):
+                for (i, tA), (j, tB) in util.multicombinations2(enumerate(self.taxa)):
                     progress.update()
                     log.info(
                         "Calculating random alignments for pair {0} / {1}.".format(tA, tB)
@@ -668,7 +662,7 @@ class LexStat(Wordlist):
             ratio=kw['ratio'],
             vscale=kw['vscale'],
             runs=kw['runs'],
-            scoring_threshold = kw['threshold'],
+            scoring_threshold=kw['threshold'],
             preprocessing_threshold=kw['preprocessing_threshold'],
             modestring=':'.join(
                 '{0}-{1}-{2:.2f}'.format(a, abs(b), c) for a, b, c in kw['modes']),
@@ -729,7 +723,7 @@ class LexStat(Wordlist):
         matrix = [[c for c in line] for line in self.bscorer.matrix]
         char_dict = self.bscorer.chars2int
 
-        for (i, tA), (j, tB) in combinations_with_replacement(enumerate(self.taxa), r=2):
+        for (i, tA), (j, tB) in util.multicombinations2(enumerate(self.taxa)):
             for charA, charB in product(
                 list(self.freqs[tA]) + [charstring(i + 1)],
                 list(self.freqs[tB]) + [charstring(j + 1)]
@@ -994,7 +988,7 @@ class LexStat(Wordlist):
             log.info("Analyzing words for concept <{0}>.".format(c))
             indices = self.get_list(row=c, flat=True)
             matrix = []
-            for idxA, idxB in combinations(indices, r=2):
+            for idxA, idxB in util.combinations2(indices):
                 try:
                     d = function(idxA, idxB)
                 except ZeroDivisionError:
@@ -1244,7 +1238,7 @@ class LexStat(Wordlist):
             function = lambda x, y: edit_dist(
                 self[x, 'tokens'], self[y, 'tokens'], normalized=edit_dist_normalized)
 
-        for taxA, taxB in combinations(self.taxa, r=2):
+        for taxA, taxB in util.combinations2(self.taxa):
             distances = []
             for pA, pB in sample(self.pairs[taxA, taxB]):
                 try:

--- a/lingpy/model/sound_change.py
+++ b/lingpy/model/sound_change.py
@@ -1,14 +1,17 @@
 """
 Module provides functions for modeling sound change.
 """
-from .. import log
-from ..algorithm import misc
-from ..sequence.sound_classes import bigrams, trigrams, pgrams, get_all_ngrams, class2tokens, ipa2tokens, prosodic_string
-from ..align.pairwise import nw_align, Pairwise, sw_align, pw_align
+from __future__ import unicode_literals, division, print_function
+from collections import defaultdict
+
+from lingpy import log
+from lingpy.sequence.sound_classes import (
+    bigrams, pgrams, get_all_ngrams, class2tokens, ipa2tokens, prosodic_string,
+)
+from lingpy.align.pairwise import Pairwise
 
 
 class SoundChanger(object):
-    
     def __init__(self, training, mode='pgrams', **keywords):
         """
         Parameters
@@ -17,19 +20,17 @@ class SoundChanger(object):
             A list of tuples, containign the ancestral and the descendant
             words.
         """
-
         self.training = training
         self.alignments = Pairwise(training)(**keywords)
-        self.ngrams = {}
-        self.converter = {}
+        self.ngrams = defaultdict(int)
+        self.converter = defaultdict(list)
 
         self.sources = [t[0] for t in training]
         self.targets = [t[1] for t in training]
         
         max_ngram = 0
 
-        for almA,almB,sim in self.alignments:
-            
+        for almA, almB, sim in self.alignments:
             if mode == 'pgrams':
                 # we need to detect gaps in target first, otherwise we cannot
                 # determine the "correct" prosodic strings in the beginning,
@@ -37,51 +38,45 @@ class SoundChanger(object):
                 gaps = [i for i in range(len(almA)) if almA[i] == '-']
 
                 # convert alignments to programs
-                pA = prosodic_string([almA[i] for i in range(len(almA)) if i
-                    not in gaps], **keywords)
-                pA = class2tokens(pA,almA)
-                progA = list(zip(almA,pA))
-                progB = pgrams(almB,**keywords)
+                pA = prosodic_string(
+                    [almA[i] for i in range(len(almA)) if i not in gaps], **keywords)
+                pA = class2tokens(pA, almA)
+                progA = list(zip(almA, pA))
+                progB = pgrams(almB, **keywords)
 
             elif mode == 'simple':
-                progA = list(zip(almA,['#']+almA[1:-1]+['$']))
-                progB = list(zip(almB,['#']+almB[1:-1]+['$']))
+                progA = list(zip(almA, ['#'] + almA[1:-1] + ['$']))
+                progB = list(zip(almB, ['#'] + almB[1:-1] + ['$']))
 
             elif mode == 'bigrams':
                 progA = bigrams(almA)
                 progB = bigrams(almB)
+            else:
+                raise ValueError(mode)
 
             # zip source and target
-            zips = list(zip(progA,progB))
+            zips = list(zip(progA, progB))
 
             # compute all ngrams
             ngrams = get_all_ngrams(zips)
 
             # iterate over all ngrams and add them to the mother dictionary
             for ngram in ngrams:
-
                 # get upper and lower
                 upper = tuple([g[0] for g in ngram if g[0][0] != '-'])
                 lower = tuple([g[1] for g in ngram if g[1][0] != '-'])
-                
-                # append to ngrams dictionary
-                try:
-                    self.ngrams[upper,lower] += 1
-                except:
-                    self.ngrams[upper,lower] = 1
 
-                try:
-                    self.converter[upper] += [lower]
-                except:
-                    self.converter[upper] = [lower]
+                self.ngrams[upper, lower] += 1
+                self.converter[upper].append(lower)
 
                 if len(upper) > max_ngram:
                     max_ngram = len(upper)
         
         # carry out post-processing of ngrams, delete all cases where ngrams
         # occur only once
-        wunnies = [ngram for ngram in self.ngrams if self.ngrams[ngram] == 1
-                and len(self.converter[ngram[0]]) == 1]
+        wunnies = [
+            ngram for ngram in self.ngrams
+            if self.ngrams[ngram] == 1 and len(self.converter[ngram[0]]) == 1]
         
         full_words = []
         part_words = []
@@ -90,8 +85,8 @@ class SoundChanger(object):
             if word in self.sources:
                 full_words += [word]
             else:
-                part_words += [(wun,word)]
-        for wun,word in part_words:
+                part_words += [(wun, word)]
+        for wun, word in part_words:
             tmp = [w for w in full_words if word in w]
             if tmp:
                 del self.ngrams[wun]
@@ -104,80 +99,71 @@ class SoundChanger(object):
         """
         self.trivials = []
         
-        for i in range(1,self._max_ngram+1):
-            
+        for i in range(1, self._max_ngram + 1):
             sources = [k[0] for k in self.ngrams if len(k[0]) == i]
-
-            for j,source in enumerate(sources):
-
+            for j, source in enumerate(sources):
                 if sources.count(source) <= 1:
+                    if not self._split_string(source):
+                        self.trivials.append(source)
 
-                    if self._split_string(source):
-                        pass
-                    else:
-                        self.trivials += [source]
-        
     def _split_string(self, sequence):
         """
-        Dynamic-programming approach to splitting all input strings into substrings which have unique counterparts in the target language.
+        Dynamic-programming approach to splitting all input strings into substrings which
+        have unique counterparts in the target language.
         """
-        queue = [[tuple([]),-1]]
+        queue = [[tuple([]), -1]]
 
         while queue:
+            current, idx = queue.pop(0)
+            log.debug(idx, current, current in self.trivials)
 
-            current,idx = queue.pop(0)
-            if log.debug(idx, current, current in self.trivials)
-
-            if idx == len(sequence)-1:
+            if idx == len(sequence) - 1:
                 if current in self.trivials:
                     return True
-            
+
             else:
-                subseq = current+tuple([sequence[idx+1]])
-                
+                subseq = current + tuple([sequence[idx + 1]])
+
                 if subseq in self.trivials:
-                    queue += [[tuple([]),idx+1]]
-                    queue += [[subseq,idx+1]]
+                    queue += [[tuple([]), idx + 1]]
+                    queue += [[subseq, idx + 1]]
                 else:
-                    queue += [[subseq, idx+1]]
-        
+                    queue += [[subseq, idx + 1]]
+
         return False
 
-    
     def transform(self, sequence, mode='pgrams', debug=False, **keywords):
-        
         if mode == 'pgrams':
             seq = tuple(pgrams(sequence, **keywords))
 
         elif mode == 'simple':
             seq = ipa2tokens(sequence)
-            seq = tuple(zip(seq,['#']+seq[1:-1]+['$']))
+            seq = tuple(zip(seq, ['#'] + seq[1:-1] + ['$']))
 
         elif mode == 'bigrams':
             seq = bigrams(ipa2tokens(sequence))
 
-        queue = [[tuple([]),-1,tuple([])]]
+        queue = [[tuple([]), -1, tuple([])]]
         output = []
 
         while queue:
+            current, idx, outseq = queue.pop(0)
 
-            current,idx,outseq = queue.pop(0)
+            log.debug(idx, current, outseq,current in self.trivials)
 
-            if log.debug(idx,current,outseq,current in self.trivials)
-
-            if idx == len(seq) -1:
+            if idx == len(seq) - 1:
                 if current in self.trivials:
-                    output += [outseq+self.converter[current][0]]
+                    output += [outseq + self.converter[current][0]]
                 else:
                     pass
             else:
-                subseq = current + tuple([seq[idx+1]])
+                subseq = current + tuple([seq[idx + 1]])
 
                 if subseq in self.trivials:
-                    queue += [[tuple([]),idx+1,outseq+self.converter[subseq][0]]]
-                    queue += [[subseq,idx+1,outseq]]
+                    queue += [[tuple([]), idx + 1, outseq + self.converter[subseq][0]]]
+                    queue += [[subseq, idx + 1, outseq]]
                 else:
-                    queue += [[subseq, idx+1, outseq]]
+                    queue += [[subseq, idx + 1, outseq]]
 
         routput = []
         for p in output:
@@ -185,5 +171,3 @@ class SoundChanger(object):
             if w not in routput:
                 routput += [w]
         return routput
-
-        

--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -66,7 +66,7 @@ class TestParser(TestCase):
         self.parser.add_entries('lTaxon', 'taxon', lambda t: t.lower(), override=True)
         assert 'ltaxon' in self.parser.entries
 
-        with patch('lingpy.basic.parser.input', Mock(return_value='y')):
+        with patch('lingpy.basic.parser.confirm', Mock(return_value=True)):
             self.parser.add_entries('ltaxon', 'taxon', lambda t: t.lower())
 
         self.parser.add_entries('tg', 'taxon,gloss', lambda v, id_: ''.join(v))

--- a/lingpy/tests/compare/test_lexstat.py
+++ b/lingpy/tests/compare/test_lexstat.py
@@ -98,7 +98,7 @@ class TestLexStat(WithTempDir):
         self.lex.cluster(method="edit-dist", threshold=0.7)
         self.lex.cluster(method="turchin", threshold=0.7)
         self.assertRaises(ValueError, self.lex.cluster, method="fuzzy")
-        with patch('lingpy.basic.parser.input', Mock(return_value='y')):
+        with patch('lingpy.basic.parser.confirm', Mock(return_value=True)):
             self.lex.cluster(method="sca", guess_threshold=True, gt_mode='nulld')
 
         assert 'scaid' in self.lex.header \

--- a/lingpy/tests/test_util.py
+++ b/lingpy/tests/test_util.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from unittest import TestCase
 
 from lingpy.tests.util import WithTempDir
 from lingpy import util
@@ -25,3 +26,24 @@ class Test(WithTempDir):
         with util.TextFile(path) as fp:
             fp.writelines(['line1\n', 'line2\n'])
         self.assertEqual(len(util.read_text_file(path, lines=True)), 2)
+
+
+class TestCombinations(TestCase):
+    def test_combinations2(self):
+        from lingpy.util import combinations2, multicombinations2
+
+        def f(l):
+            for i, a1 in enumerate(l):
+                for j, a2 in enumerate(l):
+                    if i < j:
+                        yield a1, a2
+
+        def fm(l):
+            for i, a1 in enumerate(l):
+                for j, a2 in enumerate(l):
+                    if i <= j:
+                        yield a1, a2
+
+        for l in [list(range(5)), 'abcdefg']:
+            self.assertEqual(list(combinations2(l)), list(f(l)))
+            self.assertEqual(list(multicombinations2(l)), list(fm(l)))

--- a/lingpy/tests/test_util.py
+++ b/lingpy/tests/test_util.py
@@ -30,8 +30,6 @@ class Test(WithTempDir):
 
 class TestCombinations(TestCase):
     def test_combinations2(self):
-        from lingpy.util import combinations2, multicombinations2
-
         def f(l):
             for i, a1 in enumerate(l):
                 for j, a2 in enumerate(l):
@@ -45,5 +43,15 @@ class TestCombinations(TestCase):
                         yield a1, a2
 
         for l in [list(range(5)), 'abcdefg']:
-            self.assertEqual(list(combinations2(l)), list(f(l)))
-            self.assertEqual(list(multicombinations2(l)), list(fm(l)))
+            self.assertEqual(list(util.combinations2(l)), list(f(l)))
+            self.assertEqual(list(util.multicombinations2(l)), list(fm(l)))
+
+
+class TestJoin(TestCase):
+    def test_join(self):
+        self.assertEqual(util.join('.'), '')
+        self.assertEqual(util.join('.', 1), '1')
+        self.assertEqual(util.join('.', 1, 2), '1.2')
+
+    def test_dotjoin(self):
+        self.assertEqual(util.dotjoin(1, 2), '1.2')

--- a/lingpy/util.py
+++ b/lingpy/util.py
@@ -8,6 +8,7 @@ import os
 from tempfile import NamedTemporaryFile
 from functools import partial
 import json
+import itertools
 
 from pathlib import Path
 from six import text_type, PY3
@@ -16,6 +17,29 @@ from six.moves import input
 import lingpy
 from lingpy.log import get_level, file_written
 from lingpy.settings import rcParams
+
+
+def combinations2(iterable):
+    """
+    Convenience shortcut
+    """
+    return itertools.combinations(iterable, 2)
+
+
+def multicombinations2(iterable):
+    """
+    Convenience shortcut, for the name, see the Wikipedia article on Combination.
+
+    https://en.wikipedia.org/wiki/Combination#Number_of_combinations_with_repetition
+    """
+    return itertools.combinations_with_replacement(iterable, 2)
+
+
+def join(sep, *args):
+    """
+    Convenience shortcut. Strings to be joined to not have to be passed as list or tuple.
+    """
+    return sep.join(args)
 
 
 def confirm(question, default=False):

--- a/lingpy/util.py
+++ b/lingpy/util.py
@@ -19,6 +19,13 @@ from lingpy.log import get_level, file_written
 from lingpy.settings import rcParams
 
 
+PROG = 'LingPy-{0}'.format(lingpy.__version__)
+
+
+def charstring(id_, char='X', cls='-'):
+    return '{0}.{1}.{2}'.format(id_, char, cls)
+
+
 def combinations2(iterable):
     """
     Convenience shortcut
@@ -35,11 +42,18 @@ def multicombinations2(iterable):
     return itertools.combinations_with_replacement(iterable, 2)
 
 
-def join(sep, *args):
+def join(sep, *args, **kw):
     """
-    Convenience shortcut. Strings to be joined to not have to be passed as list or tuple.
+    Convenience shortcut. Strings to be joined do not have to be passed as list or tuple.
+
+    Note: An implicit conversion of objects to strings is performed as well.
     """
-    return sep.join(args)
+    condition = kw.get('condition', lambda x: True)
+    return sep.join(['%s' % arg for arg in args if condition(arg)])
+
+
+dotjoin = partial(join, '.')
+tabjoin = partial(join, '\t')
 
 
 def confirm(question, default=False):


### PR DESCRIPTION
While I think this PR should be merged, its main intention is to exemplify the various refactorings of LingPy I would apply to make it a codebase that is more modern and easier to maintain.

Using the functionality in the python stdlib's `itertools` and `collections` modules will go along way in that direction, building up and using small but well-motivated helper functions from `lingpy.util` will go even further.

Overall the main goal of these refactorings is cutting down on linecount, which IMHO is way too big for LingPy as a whole and for many modules as well. The worst offender in this respect seems to be the assembling of output, which is intermingled in so many functions and methods. Maybe we should add and use a templating library like Jinja2 or Mako to separate most of this code?