### PR TITLE
Refactored cli module

### DIFF
--- a/lingpy/cli.py
+++ b/lingpy/cli.py
@@ -1,294 +1,353 @@
 # *-* coding: utf-8 *-*
 from __future__ import print_function, division, unicode_literals
 import lingpy
-from lingpy import *
+from lingpy.util import PROG
 import argparse
 from six import text_type as str
-
-# basic parser for lingpy
-parser = argparse.ArgumentParser(description='LingPy command line interface.')
-
-parser.add_argument('--version', action='version', version=lingpy.__version__)
-parser.add_argument('--schema', action='store', choices=['ipa', 'asjp'],    
-        default='ipa', help="Select the input schema of your transcription system.")
-parser.add_argument('--model', action='store', choices=['sca', 'dolgo', 'asjp'],
-        default='sca', help='Select your sound class model.')
-parser.add_argument('--merge-vowels', action='store', type=bool, default=True,
-        help="Indicate whether you want to merge vowels in automatic segmentation.")
-parser.add_argument('--expand-nasals', action='store', type=bool, default=False,
-        help="Indicate whether you want to display nasals in vowels as an extra segment " +\
-                'in automatic segmentation.')
-parser.add_argument('-v', '--verbose', action='store_true', default=False, 
-        help="Trigger verbose output.")
-
-# subparsers
-subparsers = parser.add_subparsers(dest="subcommand")
-
-# currently, we define two programs for examples
-parser_pairwise = subparsers.add_parser('pairwise')
-parser_multiple = subparsers.add_parser('multiple')
-parser_lexstat = subparsers.add_parser('lexstat')
-parser_wordlist = subparsers.add_parser('wordlist')
-parser_settings = subparsers.add_parser('settings')
-parser_alignments = subparsers.add_parser('alignments')
+from six import with_metaclass
 
 
-for p in [parser_pairwise, parser_multiple, parser_lexstat, parser_alignments,
-        parser_wordlist]:
-    # we take care of pairwise first
-    p.add_argument('-i', '--input-file', action='store', 
-            help="Select your input file.")
-    p.add_argument('-o', '--output-file', action='store', default='output-file',
-            help="Select the name of the output file.")
-    p.add_argument('--output', choices=["file", "stdout"], 
-            default="stdout",  
-            help="Select whether you want to have the output written to file or to screen.")
-    p.add_argument('--factor', action='store', type=float, default=0.3,
-            help="Select the factor for prosodic strings in SCA alignments.")
-    p.add_argument('--gop', action='store', type=float, default=-1,
-            help="Select your gap opening penalty.")
-    p.add_argument('--scale', action='store', type=float, default=0.5,
-            help="Select the gap extension scale.")
-    p.add_argument('--restricted-chars', action='store', default='T_',
-            help="Select the characters in the sound classes which serve to mark word " +\
-                "or morpheme boundaries.")
+class CommandMeta(type):
+    """
+    A metaclass which keeps track of subclasses, if they have all-lowercase names.
+    """
+    __instances = []
 
-# settings
-parser_settings.add_argument('-p', '--params', action='store', nargs='+', 
-        help="Indicate for which parameters you want to see the lingpy default settings.")
+    def __init__(self, name, bases, dct):
+        super(CommandMeta, self).__init__(name, bases, dct)
+        if name == name.lower():
+            self.__instances.append(self)
 
-# we take care of pairwise first
-parser_pairwise.add_argument('-s', '--strings', action='store', nargs=2,
-        type=str,
-        help="Type in the input sequences you want to align.")
-parser_pairwise.add_argument('-m', '--mode',  action='store', default='global', 
-        choices=['global', 'local', 'overlap', 'dialign'],
-        help="Select the alignment mode.")
-parser_pairwise.add_argument('-d', '--distance', action='store_true', default=False, 
-        help="Choose whether you want distances or similarities to be reported.")
-parser_pairwise.add_argument('--method', action='store', choices=['sca', 'basic'],
-        default='basic', help="Select the basic method you want to use.")
+    def __iter__(self):
+        return iter(self.__instances)
 
-# argparse for multiple
-parser_multiple.add_argument('-s', '--strings', action='store', nargs="+",
-        type=str,
-        help="Type in the input sequences you want to align.")
-parser_multiple.add_argument('-m', '--mode',  action='store', default='global', 
-        choices=['global', 'overlap', 'dialign'], 
-        help="Select the alignment mode.")
-parser_multiple.add_argument('--method', action='store', choices=['sca', 'basic'],
-        default='basic', help="Select the basic method you want to use.")
-parser_multiple.add_argument('--tree-calc', action='store', choices=['ugpma', 'neighbor'],
-        default='upgma', help="Select the tree cluster method you want to use for the guide tree.")
-parser_multiple.add_argument('--gap-weight', action='store', type=float,
-        default=0.5, help="Select the tree cluster method you want to use for the guide tree.")
-parser_multiple.add_argument('--format', action='store', default='msa', 
-        choices=['msa', 'html', 'tex', 'psa'],
-        help="Select the output format.")
-parser_multiple.add_argument('--align-method', action='store', default='library', 
-        choices=['library', 'progressive'], 
-        help="Select how you want to align, based on a library (T-COFFEE), or " +\
-                "in a classical progressive way.")
-parser_multiple.add_argument('--iteration', action='store', nargs="+", default=[],
-        choices=['orphans', 'clusters', 'similar-gap-sites', 'all-sequences'],
-        help="Select method for postprocessing.")
-parser_multiple.add_argument('--swap-check', action='store_true', default=False, 
-        help="Indicate whether you want to search for swapped sites automatically.")
 
-# args for alms (alignment of cognates in wordlists)
-parser_alignments.add_argument('-m', '--mode',  action='store', default='global', 
-        choices=['global', 'overlap', 'dialign'], 
-        help="Select the alignment mode.")
-parser_alignments.add_argument('--method', action='store', choices=['sca', 'basic'],
-        default='basic', help="Select the basic method you want to use.")
-parser_alignments.add_argument('--tree-calc', action='store', choices=['ugpma', 'neighbor'],
-        default='upgma', help="Select the tree cluster method you want to use for the guide tree.")
-parser_alignments.add_argument('--gap-weight', action='store', type=float,
-        default=0.5, help="Select the tree cluster method you want to use for the guide tree.")
-parser_alignments.add_argument('--format', action='store', default='tsv', 
-        choices=['msa', 'html', 'tsv'],
-        help="Select the output format.")
-parser_alignments.add_argument('--align-method', action='store', default='library', 
-        choices=['library', 'progressive'], 
-        help="Select how you want to align, based on a library (T-COFFEE), or " +\
-                "in a classical progressive way.")
-parser_alignments.add_argument('--iterate', action='store_true', default=False,
-        help="Choose whether you want to make postprocessing using iteration methods.")
-parser_alignments.add_argument('-c','--cognate-identifier', action='store',
-        default='lingpyid', 
-        help='Select the name for the column with the cognate judgments.')
-parser_alignments.add_argument('--alignment-identifier', action='store',
-        default='alignment', 
-        help='Select the name for the column with the alignments.')
-parser_alignments.add_argument('--use-logodds', action='store_true',
-        default=False, 
-        help='Use logodds from LexStat to calculate the alignments.')
+class Command(with_metaclass(CommandMeta, object)):
+    """Base class for subcommands of the lingpy command line interface."""
+    help = None
 
-# args for lexstat
-parser_lexstat.add_argument('--method', action='store', default='sca',
-        choices=['lexstat', 'sca','edit-dist','turchin'], 
-        help='Select the method you want to use for cognate detection.')
-parser_lexstat.add_argument('--runs', action='store', type=int, default=1000,
-        help='Select the number of iterations for the permutation test.')
-parser_lexstat.add_argument('--check', action='store_true', default=False, 
-        help='Specify whether you want to carry out a check before running your analysis.')
-parser_lexstat.add_argument('--scoring-threshold', action='store',
-        default=lingpy.settings.rcParams['lexstat_scoring_threshold'],
-        help='Select the threshold to be used when creating the scorer.')
-parser_lexstat.add_argument('-t', '--threshold', action='store', type=float,
-        default=0.45,
-        help='Select the threshold to be used when creating the scorer.')
-parser_lexstat.add_argument('-c','--cognate-identifier', action='store',
-        default='lingpyid', 
-        help='Select the name for the column with the cognate judgments.')
-parser_lexstat.add_argument('--cluster-method', action='store',
-        default='upgma', 
-        choices=['upgma', 'single', 'complete', 'mcl', 'ward',
-        'link_clustering'],
-        help='Select the name of the cluster method you want to use.')
-parser_lexstat.add_argument('--ratio', action='store', nargs=2, type=int,
-        default=[2,1],
-        help='Select the ratio between the logodds and the sound class scorer.')
+    @classmethod
+    def subparser(cls, parser):
+        """Hook to define subcommand arguments."""
+        return
 
-# wordlist parameters
-parser_wordlist.add_argument('--check', action='store_true', default=False, 
-        help='Check the content of your wordlist.')
-parser_wordlist.add_argument('--stats', action='store_true', default=False, 
-        help='Retrieve basic statistics of your wordlist.')
-parser_wordlist.add_argument('-t', '--transform', action='store_true', default=False,
-        help='Transform your wordlist.')
-parser_wordlist.add_argument('-c','--cognate-identifier', action='store',
-        default='cogid', 
-        help='Select the name for the column with the cognate judgments.')
-parser_wordlist.add_argument('--cluster-method', action='store',
-        default='upgma', 
-        choices=['upgma', 'single', 'complete', 'mcl', 'ward',
-        'link_clustering'],
-        help='Select the name of the cluster method you want to use.')
-parser_wordlist.add_argument('--colums', action='store', nargs='+',
-        help="Select the columns and the order in which you want to write your wordlist file.")
-parser_wordlist.add_argument('--add-row', action='store', nargs=3, default=['ipa',
-    'tokens', 'ipa2tokens'], 
-    help='Add rows to wordlist by converting source with target via function.')
-parser_wordlist.add_argument('--calculate', action='store', default='',
-        choices=['dst', 'tree', 'diversity'],
-        help="Calculate a tree from the wordlist.")
-parser_wordlist.add_argument('--format', action='store', default='tsv', 
-        choices=['dst', 'taxa', 'paps.nex', 'nwk', 'cluster', 'starling',
-        'multistate.nex', 'separated'],
-        help="Select the output format.")
-parser_wordlist.add_argument('--tree-calc', action='store', choices=['ugpma', 'neighbor'],
-        default='upgma', help="Select the tree cluster method you want to use for the guide tree.")
-parser_wordlist.add_argument('--missing', action='store', default='?',
-        help="Missing value for the output to Nexus files.")
+    def output(self, args, content):
+        if args.output_file:
+            lingpy.util.write_text_file(args.output_file, content)
+        else:
+            print(content)
 
-def wordlist(args):
+    def __call__(self, args):
+        """Hook to run the subcommand."""
+        raise NotImplemented()
+
+
+def _cmd_by_name(name):
+    for cmd in Command:
+        if cmd.__name__ == name:
+            return cmd()
+
+
+def add_option(parser, name_, default_, help_, short_opt=None, **kw):
+    names = ['--' + name_]
+    if short_opt:
+        names.append('-' + short_opt)
+
+    if isinstance(default_, bool):
+        kw['action'] = 'store_false' if default_ else 'store_true'
+    elif isinstance(default_, int):
+        kw['type'] = float
+    elif isinstance(default_, float):
+        kw['type'] = float
+    kw['default'] = default_
+    kw['help'] = help_
+    parser.add_argument(*names, **kw)
+
+
+def add_shared_args(p):
+    add_option(p, 'input-file', None, "Path to input file.", short_opt='i')
+    add_option(p, 'output-file', None, "Path to output file.", short_opt='o')
+    add_option(p, 'factor', 0.3, "Factor for prosodic strings in SCA alignments.")
+    add_option(p, 'gop', -1.0, "Gap opening penalty.")
+    add_option(p, 'scale', 0.5, "Gap extension scale.")
+    add_option(
+        p,
+        'restricted-chars',
+        'T_',
+        "Characters in the sound classes which mark word or morpheme boundaries.")
+
+
+def add_cognate_identifier_option(p, default):
+    add_option(
+        p,
+        'cognate-identifier',
+        default,
+        'Name for the column with the cognate judgments.',
+        short_opt='c')
+
+
+def add_tree_calc_option(p):
+    add_option(
+        p,
+        'tree-calc',
+        'upgma',
+        "Select the tree cluster method you want to use for the guide tree.",
+        choices=['ugpma', 'neighbor'])
+
+
+def add_method_option(p, default, choices, spec=''):
+    add_option(
+        p,
+        'method',
+        default,
+        "The %s method you want to use." % spec,
+        choices=choices)
+
+
+def add_format_option(p, default, choices):
+    add_option(p, 'format', default, "Output format.", choices=choices)
+
+
+def add_strings_option(p, n):
+    add_option(
+        p, 'strings', None, "Input sequences you want to align.", nargs=n, short_opt='s')
+
+
+def add_mode_option(p, choices):
+    add_option(p, 'mode', 'global', 'Alignment mode', choices=choices, short_opt='m')
+
+
+class wordlist(Command):
     """
     Load a wordlist and carry out simple checks.
     """
-    if args.input_file:
-        if args.check:
-            wl = lingpy.compare.lexstat.LexStat(args.input_file, check=True)
-        else:
-            wl = lingpy.basic.wordlist.Wordlist(args.input_file)
+    @classmethod
+    def subparser(cls, p):
+        add_shared_args(p)
+        add_option(p, 'check', False, 'Check the content of your wordlist.')
+        add_option(p, 'stats', False, 'Retrieve basic statistics of your wordlist.')
+        add_option(p, 'transform', False, 'Transform your wordlist.', short_opt='t')
+        add_cognate_identifier_option(p, 'cogid')
+        add_option(
+            p,
+            'cluster-method',
+            'upgma',
+            'Cluster method you want to use.',
+            choices=['upgma', 'single', 'complete', 'mcl', 'ward', 'link_clustering'])
+        add_option(
+            p,
+            'columns',
+            None,
+            "Select the columns and the order in which you want to write your wordlist file.",
+            nargs='+')
+        add_option(
+            p,
+            'add-row',
+            ['ipa', 'tokens', 'ipa2tokens'],
+            'Add rows to wordlist by converting source with target via function.',
+            nargs=3)
+        add_option(
+            p,
+            'calculate',
+            '',
+            "Calculate a tree from the wordlist.",
+            choices=['dst', 'tree', 'diversity'])
+        add_format_option(
+            p,
+            'tsv',
+            ['dst', 'taxa', 'paps.nex', 'nwk', 'cluster', 'starling', 'multistate.nex',
+             'separated'])
+        add_option(
+            p,
+            'tree-calc',
+            'upgma',
+            "Select the tree cluster method you want to use for the guide tree.",
+            choices=['ugpma', 'neighbor'])
+        add_option(p, 'missing', '?', "Missing value for the output to Nexus files.")
 
-        # process stuff according to arguments, will surely need to be further
-        # refined
-        if args.stats:
-            print('---BASIC---')
-            print('Height:  {0}'.format(wl.height))
-            print('Width:   {0}'.format(wl.width))
-            print('Length:  {0}'.format(len(wl)))
-            print('')
-            print('---COVERAGE---')
-            for k, v in wl.coverage(stats='absolute').items():
-                print('{0:20}  :  {1}'.format(k, v))
-            print('')
-        if args.calculate:
-            wl.calculate(args.calculate, ref=args.cognate_identifier,
-                    tree_calc=args.tree_calc)
-            if args.output == 'stdout':
-                if args.calculate == 'tree':
-                    print('---TREE---')
-                    print(wl.tree.asciiArt())
-                if args.calculate == 'diversity':
-                    print('---DIVERSITY---')
-                    print(wl.diversity)
+    def __call__(self, args):
+        if args.input_file:
+            if args.check:
+                wl = lingpy.compare.lexstat.LexStat(args.input_file, check=True)
+            else:
+                wl = lingpy.basic.wordlist.Wordlist(args.input_file)
 
-        if args.output == 'file':
-            wl.output(args.format, filename=args.output_file,
+            # process stuff according to arguments, will surely need to be further
+            # refined
+            if args.stats:
+                print('---BASIC---')
+                print('Height:  {0}'.format(wl.height))
+                print('Width:   {0}'.format(wl.width))
+                print('Length:  {0}'.format(len(wl)))
+                print('')
+                print('---COVERAGE---')
+                for k, v in wl.coverage(stats='absolute').items():
+                    print('{0:20}  :  {1}'.format(k, v))
+                print('')
+            if args.calculate:
+                wl.calculate(args.calculate, ref=args.cognate_identifier,
+                             tree_calc=args.tree_calc)
+                if not args.output_file:
+                    if args.calculate == 'tree':
+                        print('---TREE---')
+                        print(wl.tree.asciiArt())
+                    if args.calculate == 'diversity':
+                        print('---DIVERSITY---')
+                        print(wl.diversity)
+
+            if args.output_file:
+                wl.output(
+                    args.format, filename=args.output_file,
                     ref=args.cognate_identifier, missing=args.missing)
 
-        return wl.height, wl.width, len(wl) 
 
-def alignments(args):
+class alignments(Command):
     """
     Carry out alignment analysis of a wordlist file with readily detected cognates.
-
     """
-    if args.input_file:
-        alms = lingpy.align.sca.Alignments(args.input_file, 
-                merge_vowels=args.merge_vowels,
+    @classmethod
+    def subparser(cls, p):
+        add_shared_args(p)
+        add_option(
+            p,
+            'mode',
+            'global',
+            "Select the alignment mode.",
+            choices=['global', 'overlap', 'dialign'],
+            short_opt='m')
+        add_method_option(p, 'basic', ['sca', 'basic'])
+        add_tree_calc_option(p)
+        add_option(p, 'gap-weight', 0.5, 'Gap weight.')
+        add_format_option(p, 'tsv', ['msa', 'html', 'tsv'])
+        add_option(
+            p,
+            'align-method',
+            'library',
+            "Select how you want to align, based on a library (T-COFFEE), or " +
+            "in a classical progressive way.",
+            choices=['library', 'progressive'])
+        add_option(p, 'iterate', False, "Postprocess using iteration methods.")
+        add_cognate_identifier_option(p, 'lingpyid')
+        add_option(
+            p,
+            'alignment-identifier',
+            'alignment',
+            'Name for the column with the alignments.')
+        add_option(
+            p,
+            'use-logodds',
+            False,
+            'Use logodds from LexStat to calculate the alignments.')
+
+    def __call__(self, args):
+        if args.input_file:
+            alms = lingpy.align.sca.Alignments(
+                args.input_file,
+                merge_vowels=not args.no_merged_vowels,
                 expand_nasals=args.expand_nasals,
                 ref=args.cognate_identifier,
                 alignment=args.alignment_identifier)
-        if args.use_logodds:
-            lex = lingpy.compare.lexstat.LexStat(args.input_file)
-            if not hasattr(lex, 'cscorer'):
-                raise ValueError("No scorer has been submitted along with your file.")
-            scoredict = lex.cscorer
-        else:
-            scoredict = False
-        alms.align(method=args.align_method, gop=args.gop, scale=args.scale,
-                factor=args.factor, iteration=args.iterate, model=args.model,
-                tree_calc=args.tree_calc,
-                restricted_chars=args.restricted_chars, mode=args.mode)
-        alms.output(args.format, filename=args.output_file, ignore='all')
+            if args.use_logodds:
+                lex = lingpy.compare.lexstat.LexStat(args.input_file)
+                if not hasattr(lex, 'cscorer'):
+                    raise ValueError("No scorer has been submitted along with your file.")
+            alms.align(method=args.align_method, gop=args.gop, scale=args.scale,
+                       factor=args.factor, iteration=args.iterate, model=args.model,
+                       tree_calc=args.tree_calc,
+                       restricted_chars=args.restricted_chars, mode=args.mode)
+            alms.output(args.format, filename=args.output_file, ignore='all')
+            return alms.msa[args.cognate_identifier]
 
-        return alms.msa[args.cognate_identifier]
 
-def settings(args):
-    out = []
-    for param in args.params:
-        if param in lingpy.settings.rcParams:
-            print('{0:20} : {1}'.format(param, repr(lingpy.settings.rc(param))))
-        else:
-            print('{0:20} : PARAMETER NOT FOUND'.format(param))
-        out += [[param, lingpy.settings.rc(param) if param in
-            lingpy.settings.rcParams else 'PARAMETER NOT FOUND']]
-    return out
+class settings(Command):
+    @classmethod
+    def subparser(cls, p):
+        add_option(
+            p,
+            'params',
+            None,
+            "Parameter names to show default settings for.",
+            nargs='+',
+            short_opt='p')
 
-def lexstat(args):
-    if args.input_file:
-        lex = lingpy.compare.lexstat.LexStat(args.input_file, 
-                merge_vowels=args.merge_vowels,
+    def __call__(self, args):
+        for k, v in lingpy.settings.rcParams.items():
+            if not args.params or k in args.params:
+                print('{0:20} : {1}'.format(k, repr(v)))
+
+
+class lexstat(Command):
+    @classmethod
+    def subparser(cls, p):
+        add_shared_args(p)
+        add_method_option(
+            p,
+            'sca',
+            ['lexstat', 'sca', 'edit-dist', 'turchin'],
+            spec='cognate detection')
+        add_option(p, 'runs', 1000, 'Number of iterations for the permutation test.')
+        add_option(p, 'check', False, 'Carry out a check before running your analysis.')
+        add_option(
+            p,
+            'scoring-threshold',
+            lingpy.settings.rcParams['lexstat_scoring_threshold'],
+            'Select the threshold to be used when creating the scorer.')
+        add_option(
+            p,
+            'threshold',
+            0.45,
+            'Select the threshold to be used when creating the scorer.',
+            short_opt='t')
+        add_cognate_identifier_option(p, 'lingpyid')
+        add_option(
+            p,
+            'cluster-method',
+            'upgma',
+            'Select the name of the cluster method you want to use.',
+            choices=['upgma', 'single', 'complete', 'mcl', 'ward', 'link_clustering'])
+        add_option(
+            p,
+            'ratio',
+            [2, 1],
+            'Ratio between the logodds and the sound class scorer.',
+            nargs=2,
+            type=int)
+
+    def __call__(self, args):
+        if args.input_file:
+            lex = lingpy.compare.lexstat.LexStat(
+                args.input_file,
+                merge_vowels=not args.no_merged_vowels,
                 expand_nasals=args.expand_nasals,
                 check=args.check
-                )
-        if args.verbose:
-            print("[i] Loaded file {0}.".format(args.input_file))
+            )
+            if args.verbose:
+                print("[i] Loaded file {0}.".format(args.input_file))
 
-        if args.method == 'lexstat':
-            # check for existing scorer
-            if not hasattr(lex, 'cscorer'):
-                lex.get_scorer(runs=args.runs, preprocessing=False, 
-                        ratio=args.ratio, factor=args.factor,
-                        threshold=args.scoring_threshold,
-                        restricted_chars=args.restricted_chars)
-                if args.verbose:
-                    print("[i] Calculated the scorer.")
-            else:
-                if args.verbose:
-                    print("[i] Scorer has already been calculated. Skipping re-calculation.")
-        lex.cluster(args.method, threshold=args.threshold,
-                cluster_method=args.cluster_method, scale=args.scale,
-                factor=args.factor, restricted_chars=args.restricted_chars,
-                gop=args.gop, ref=args.cognate_identifier)
-        if args.verbose: print("[i] Clustered the data.")
-        lex.output('tsv', filename=args.output_file)
+            if args.method == 'lexstat':
+                # check for existing scorer
+                if not hasattr(lex, 'cscorer'):
+                    lex.get_scorer(runs=args.runs, preprocessing=False,
+                                   ratio=args.ratio, factor=args.factor,
+                                   threshold=args.scoring_threshold,
+                                   restricted_chars=args.restricted_chars)
+                    if args.verbose:
+                        print("[i] Calculated the scorer.")
+                else:
+                    if args.verbose:
+                        print(
+                            "[i] Scorer has already been calculated. Skipping re-calculation.")
+            lex.cluster(args.method, threshold=args.threshold,
+                        cluster_method=args.cluster_method, scale=args.scale,
+                        factor=args.factor, restricted_chars=args.restricted_chars,
+                        gop=args.gop, ref=args.cognate_identifier)
+            if args.verbose:
+                print("[i] Clustered the data.")
+            lex.output('tsv', filename=args.output_file)
         return len(lex.get_etymdict(ref=args.cognate_identifier))
 
-def pairwise(args):
+
+class pairwise(Command):
     """
     Run pairwise analyses from command line in LingPy
 
@@ -305,48 +364,53 @@ def pairwise(args):
     * define user input using psa-formats in lingpy
     * define user output (stdout, file)
     """
-    make_out = lambda x, y, z: '\t'.join(x)+'\n'+'\t'.join(y)+'\n{0:.2f}'.format(z)
-    if args.strings:
-        if args.method == 'basic':
-            almA, almB, sim = lingpy.align.pairwise.pw_align(
-                    args.strings[0], 
-                    args.strings[1],
-                    **args.__dict__
-                    )
-        else:
-            pair = lingpy.align.pairwise.Pairwise(*args.strings, merge_vowels=args.merge_vowels,
-                    expand_nasals=args.expand_nasals)
-            pair.align(**args.__dict__)
-            almA, almB, sim = pair.alignments[0]
-        output = make_out(almA, almB, sim)
-        if args.output == 'file':
-            lingpy.util.write_text_file(args.output_file, output)
-        else:
-            print(output)
-        return almA, almB, sim
-    elif args.input_file:
-        pairs = lingpy.align.sca.PSA(args.input_file)
-        output = ''
-        if args.method == 'basic':
-            for i, (seqA, seqB) in enumerate(pairs.tokens):
-                almA, almB, sim = lingpy.align.pairwise.pw_align(
-                        ''.join(seqA),
-                        ''.join(seqB)
-                        ,
-                        **args.__dict__)
-                pairs.alignments[i] = [almA, almB, sim]
-                output += make_out(almA, almB, sim)+'\n'
-        elif args.method == 'sca':
-            pairs.align(**args.__dict__)
-            for almA, almB, sim in pairs.alignments:
-                output += make_out(almA, almB, sim)+'\n'
-        if args.output == 'file':
-            pairs.output('psa', filename=args.output_file)
-        else:
-            print(output)
-        return pairs.alignments
+    @classmethod
+    def subparser(cls, p):
+        add_shared_args(p)
+        add_strings_option(p, 2)
+        add_mode_option(p, ['global', 'local', 'overlap', 'dialign'])
+        p.add_argument('-d', '--distance', action='store_true', default=False,
+                                     help="Choose whether you want distances or similarities to be reported.")
+        add_method_option(p, 'basic', ['sca', 'basic'], spec='basic')
 
-def multiple(args):
+    def __call__(self, args):
+        def make_out(x, y, z):
+            return '\t'.join(x) + '\n' + '\t'.join(y) + '\n{0:.2f}'.format(z)
+
+        if args.strings:
+            if args.method == 'basic':
+                almA, almB, sim = lingpy.align.pairwise.pw_align(
+                    args.strings[0], args.strings[1], **args.__dict__)
+            else:
+                pair = lingpy.align.pairwise.Pairwise(
+                    *args.strings,
+                    merge_vowels=not args.no_merged_vowels,
+                    expand_nasals=args.expand_nasals)
+                pair.align(**args.__dict__)
+                almA, almB, sim = pair.alignments[0]
+
+            self.output(args, make_out(almA, almB, sim))
+        elif args.input_file:
+            pairs = lingpy.align.sca.PSA(args.input_file)
+            output = ''
+            if args.method == 'basic':
+                for i, (seqA, seqB) in enumerate(pairs.tokens):
+                    almA, almB, sim = lingpy.align.pairwise.pw_align(
+                        ''.join(seqA), ''.join(seqB), **args.__dict__)
+                    pairs.alignments[i] = [almA, almB, sim]
+                    output += make_out(almA, almB, sim) + '\n'
+            elif args.method == 'sca':
+                pairs.align(**args.__dict__)
+                for almA, almB, sim in pairs.alignments:
+                    output += make_out(almA, almB, sim) + '\n'
+
+            if args.output_file:
+                pairs.output('psa', filename=args.output_file)
+            else:
+                print(output)
+
+
+class multiple(Command):
     """
     Multiple alignment console interface for LingPy.
 
@@ -354,96 +418,156 @@ def multiple(args):
     -----
 
     """
-    def align_msa(msa, args):
-        if args.method == 'library':
-            msa.lib_align(**args.__dict__)
-        else:
-            msa.prog_align(**args.__dict__)
-        if 'orphans' in args.iteration: msa.iterate_orphans()
-        if 'clusters' in args.iteration: msa.iterate_clusters()
-        if 'similar-gap-sites' in args.iteration: msa.iterate_similar_gap_sites()
-        if 'all-sequences' in args.iteration: msa.iterate_all_sequences()
-        if args.swap_check: msa.swap_check()
+    @classmethod
+    def subparser(cls, p):
+        add_shared_args(p)
+        add_strings_option(p, '+')
+        add_mode_option(p, ['global', 'overlap', 'dialign'])
+        add_method_option(p, 'basic', ['sca', 'basic'], spec='basic')
+        add_tree_calc_option(p)
+        p.add_argument('--gap-weight', action='store', type=float,
+                                     default=0.5,
+                                     help="Select the tree cluster method you want to use for the guide tree.")
+        add_format_option(p, 'msa', ['msa', 'html', 'tex', 'psa'])
+        p.add_argument('--align-method', action='store', default='library',
+                                     choices=['library', 'progressive'],
+                                     help="Select how you want to align, based on a library (T-COFFEE), or " + \
+                                          "in a classical progressive way.")
+        p.add_argument('--iteration', action='store', nargs="+", default=[],
+                                     choices=['orphans', 'clusters', 'similar-gap-sites',
+                                              'all-sequences'],
+                                     help="Select method for postprocessing.")
+        p.add_argument('--swap-check', action='store_true', default=False,
+                                     help="Indicate whether you want to search for swapped sites automatically.")
 
-    if args.strings:
-        if args.method == 'basic':
-            alms = lingpy.align.multiple.mult_align(
+    def __call__(self, args):
+        def align_msa(msa, args):
+            if args.method == 'library':
+                msa.lib_align(**args.__dict__)
+            else:
+                msa.prog_align(**args.__dict__)
+            if 'orphans' in args.iteration:
+                msa.iterate_orphans()
+            if 'clusters' in args.iteration:
+                msa.iterate_clusters()
+            if 'similar-gap-sites' in args.iteration:
+                msa.iterate_similar_gap_sites()
+            if 'all-sequences' in args.iteration:
+                msa.iterate_all_sequences()
+            if args.swap_check:
+                msa.swap_check()
+
+        if args.strings:
+            if args.method == 'basic':
+                alms = lingpy.align.multiple.mult_align(
                     args.strings,
                     pprint=False,
                     gop=args.gop,
                     tree_calc=args.tree_calc,
                     scoredict=False,
                     scale=args.scale,
-                    )
-        elif args.method == 'sca':
-            msa = lingpy.align.multiple.Multiple(args.strings, merge_vowels=args.merge_vowels,
-                    expand_nasals=args.expand_nasals, model=args.model)
-            align_msa(msa, args)
-            alms = msa.alm_matrix
-        
-        output = '\n'.join(['\t'.join(seq) for seq in alms])
-        if args.output == 'file':
-            lingpy.util.write_text_file(args.output_file, output)
-        else:
-            print(output)
-        return alms
-    elif args.input_file:
-        msa = lingpy.align.sca.MSA(args.input_file, merge_vowels=args.merge_vowels,
-                    expand_nasals=args.expand_nasals, model=args.model)
-        if args.method == 'basic':
-            seqs = [str(''.join(t)) for t in msa.tokens]
-            print(seqs)
-            alms = lingpy.align.multiple.mult_align(
+                )
+            elif args.method == 'sca':
+                msa = lingpy.align.multiple.Multiple(args.strings,
+                                                     merge_vowels=not args.no_merged_vowels,
+                                                     expand_nasals=args.expand_nasals,
+                                                     model=args.model)
+                align_msa(msa, args)
+                alms = msa.alm_matrix
+
+            self.output(args, '\n'.join(['\t'.join(seq) for seq in alms]))
+            return alms
+
+        if args.input_file:
+            msa = lingpy.align.sca.MSA(args.input_file, merge_vowels=not args.no_merged_vowels,
+                                       expand_nasals=args.expand_nasals, model=args.model)
+            if args.method == 'basic':
+                seqs = [str(''.join(t)) for t in msa.tokens]
+                print(seqs)
+                alms = lingpy.align.multiple.mult_align(
                     seqs,
                     pprint=False,
                     gop=args.gop,
                     tree_calc=args.tree_calc,
                     scoredict=False,
                     scale=args.scale,
-                    )
-            msa.alm_matrix = []
-            for alm in alms:
-                msa.alm_matrix += [alm]
-        else:
-            align_msa(msa, args)
-        if args.output == 'file':
-            msa.output(args.format, filename=args.output_file)
-        else:
-            for taxon, alm in zip(msa.taxa, msa.alm_matrix):
-                print('{0}\t{1}'.format(taxon, '\t'.join(alm)))
-        return msa.taxa, msa.alm_matrix
-    
-def main():
+                )
+                msa.alm_matrix = []
+                for alm in alms:
+                    msa.alm_matrix += [alm]
+            else:
+                align_msa(msa, args)
+            if args.output_file:
+                msa.output(args.format, filename=args.output_file)
+            else:
+                for taxon, alm in zip(msa.taxa, msa.alm_matrix):
+                    print('{0}\t{1}'.format(taxon, '\t'.join(alm)))
+            return msa.taxa, msa.alm_matrix
+
+
+class help(Command):
     """
-    Basic command line interface function for LingPy
-
-    Notes
-    -----
-    Major options for main in global are:
-
-    * schema (ipa, asjp): select the alphabet underlying the input strings
-    * model (sca, dolgo, asjp): selct the major sound-class model to be used
-
-    
+    Show help for commands.
     """
-    # parse arguments
-    args = parser.parse_args()
-    
-    # make up for basic configs
+    @classmethod
+    def subparser(self, parser):
+        parser.add_argument(
+            'cmd', choices=[cmd.__name__ for cmd in Command if cmd.__name__ != 'help'])
+
+    def __call__(self, args):
+        cmd = _cmd_by_name(args.cmd)
+        if cmd.__doc__:
+            print('\n%s\n' % cmd.__doc__.strip())
+        print(cmd.help)
+
+
+def get_parser():
+    # basic parser for lingpy
+    parser = argparse.ArgumentParser(
+        description=main.__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    add_option(parser, 'version', None, '', action='version', version=PROG)
+    add_option(
+        parser,
+        'schema',
+        'ipa',
+        "Input schema of your transcription system.",
+        choices=['ipa', 'asjp'])
+    add_option(
+        parser,
+        'model',
+        'sca',
+        'Select your sound class model.',
+        choices=['sca', 'dolgo', 'asjp'])
+    add_option(
+        parser,
+        'no-merged-vowels',
+        False,
+        'Do not merge vowels in automatic segmentation.')
+    add_option(
+        parser,
+        'expand-nasals',
+        False,
+        "Display nasals in vowels as an extra segment in automatic segmentation.")
+    add_option(parser, 'verbose', False, 'Trigger verbose output.', short_opt='v')
+
+    subparsers = parser.add_subparsers(dest="subcommand")
+    for cmd in Command:
+        subparser = subparsers.add_parser(
+            cmd.__name__,
+            help=(cmd.__doc__ or '').strip().split('\n')[0],
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        cmd.subparser(subparser)
+        cmd.help = subparser.format_help()
+
+    return parser
+
+
+def main(*args):
+    """
+    LingPy command line interface.
+    """
+    args = get_parser().parse_args(args or None)
     lingpy.rc(schema=args.schema)
     lingpy.rc(model=lingpy.settings.rcParams[args.model])
-    
-    if args.subcommand == "pairwise":
-        pairwise(args)
-    if args.subcommand == 'multiple':
-        multiple(args)
-    if args.subcommand == 'settings':
-        settings(args)
-    if args.subcommand == 'lexstat':
-        lexstat(args)
-    if args.subcommand == 'alignments':
-        alignments(args)
-    if args.subcommand == 'wordlist':
-        wordlist(args)
-
-
+    return _cmd_by_name(args.subcommand)(args)

--- a/lingpy/tests/test_cli.py
+++ b/lingpy/tests/test_cli.py
@@ -31,20 +31,13 @@ class Tests(WithTempDir):
         self.assertIn('Height:  200', output)
 
     def test_alignments(self):
-        alms = main('alignments', '-i',
-                                  test_data('KSL.qlc'), '-c', 'cogid', '--output-file',
-                                  self.tmp_path('alignments').as_posix())
-        assert 'German' in alms[1]['taxa']
-        assert len(alms[952]['alignment'][0]) == len(alms[952]['alignment'][1])
+        tmp = self.tmp_path('alignments')
 
-        # test html output and scorer which was computed before
-        alms = main('alignments', '-i',
-                                  test_data('KSL3.qlc'), '-c', 'cogid', '--output-file',
-                                  self.tmp_path('alignments').as_posix(), '--format',
-                                  'html',
-                                  '--use-logodds')
-        assert 'German' in alms[78]['taxa']
-        assert len(alms[884]['alignment'][0]) == len(alms[884]['alignment'][1])
+        def cmd(i, rem=''):
+            return 'alignments -i {0} -c cogid -o {1} {2}'.format(i, tmp.as_posix(), rem)
+
+        self.run_cli(cmd(test_data('KSL.qlc')))
+        self.run_cli(cmd(test_data('KSL3.qlc'), ' --format html --use-logodds'))
 
     def test_multiple(self):
         # first test, align string, no output, no input


### PR DESCRIPTION
The `lingpy.cli` module has been refactored along the following design goals:

- keep locality of subcommand implementation and subcommand argument parsing
- test the actual cli functionality, i.e. check output written to the terminal, rather than custom return values from subcommands.

This has been done using two "high-level" techniques:

- Subcommands are now classes inheriting from `lingpy.cli.Command` (which uses some metaclass magic to keep track of all derived classes). The `__call__` method of these classes implements the actual functionality, whereas a method `subparser` can be overwritten to add subcomand-specific arguments to the subparser.
- `lingpy.tests.test_cli.Tests` implements a method `run_cli`, which redirects `stdout` before running a command, so that the output normally written to `stdout` can be inspected in the tests.
