### PR TITLE
LexStat pairs: homonyms

### DIFF
--- a/lingpy/compare/lexstat.py
+++ b/lingpy/compare/lexstat.py
@@ -308,10 +308,7 @@ class LexStat(Wordlist):
                 if i < j:
                     for c in sorted(set(dictA).intersection(dictB)):
                         for idxA, idxB in product(dictA[c], dictB[c]):
-                            dA = self[idxA, "duplicates"]
-                            dB = self[idxB, "duplicates"]
-                            if dA != 1 and dB != 1:
-                                self.pairs[taxonA, taxonB] += [(idxA, idxB)]
+                            self.pairs[taxonA, taxonB] += [(idxA, idxB)]
                 elif i == j:
                     for c in sorted(dictA):
                         for idx in dictA[c]:

--- a/lingpy/tests/compare/test_lexstat.py
+++ b/lingpy/tests/compare/test_lexstat.py
@@ -172,3 +172,12 @@ class TestLexStat(WithTempDir):
         lex.cluster(method='sca', threshold=0.5, ref='cogid')
         self.assertEquals(lex[1, 'cogid'], lex[2, 'cogid'], lex[3, 'cogid'])
         rc(schema='ipa')
+
+    def test_pairs(self):
+        pairs = self.lex.pairs['English', 'German']
+        for key1, key2 in pairs:
+            self.assertEqual(self.lex[key1][0], 'English')
+            self.assertEqual(self.lex[key2][0], 'German')
+            self.assertEqual(self.lex[key1][1], self.lex[key2][1])
+            self.assertEqual(self.lex[key1][2], self.lex[key2][2])
+        self.assertEqual(len(pairs), 200)


### PR DESCRIPTION
This might be intended behaviour; if so, then consider this pull request a call for better docs :)

The `pairs` property of `LexStat` instances ignores homonyms. Taking the `KSL.qlc` test fixture as an example, the English/German pairs will only include one of the English glosses for _I_ and _eye_, because these have the same IPA transcription. So we will get _I_/_ich_ or _eye_/_Auge_, but not both.

The first commit adds a failing unit test (the test fixture should include 200 pairs instead of 195). The second commit barbarically deletes the problematic code; of course, this code seems to be there for a purpose, but all unit tests are OK, which might be a different problem altogether.