### PR TITLE
fixing one bug and adding a new funciton to clean a sequence from bad text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.16093.svg)](http://dx.doi.org/10.5281/zenodo.16093)
 [![PyPI version](https://badge.fury.io/py/lingpy.png)](https://badge.fury.io/py/lingpy)
 [![Documentation](https://readthedocs.org/projects/lingpy/badge/?version=latest)](http://lingpy.readthedocs.org/en/latest/?badge=latest)
+[![Downloads](https://img.shields.io/pypi/dm/lingpy.svg)](https://pypi.python.org/pypi/lingpy)
 
 
 

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -33,7 +33,7 @@ LingPy
  <div id="footer" style="align-items:center;padding-top:5px;padding-left:0px;display:flex;justify-content:space-between;">
 
    <div>
-     <a href="http://ssh.mpg.de"><img width="60px" src="{{ pathto('_static/minerva.png', 1) }}" alt="MPG-SSH" /></a>
+     <a href="http://shh.mpg.de"><img width="60px" src="{{ pathto('_static/minerva.png', 1) }}" alt="MPG-SSH" /></a>
    </div>
   <div>
     <a href="http://dfg.de/"><img width="80px" src="{{ pathto('_static/dfg_logo_schwarz.jpg', 1) }}" alt="DFG" /></a>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -81,8 +81,7 @@ today = str(datetime.datetime.today()).split(' ')[0]
 rst_prolog = """
 .. |authors| replace:: {authors}
 .. |contributors| replace:: {collaborators}
-.. |quoteas| replace:: List, Johann-Mattis and Forkel, Robert ({year}): **LingPy.  A Python library for historical linguistics**. Version {version}. URL: http://lingpy.org, DOI: https://zenodo.org/badge/latestdoi/5137/lingpy/lingpy.  With collaborations by {collaborators}. Jena: Max Planck Institute for the Science of Human History.
-
+.. |quoteas| replace:: List, Johann-Mattis and Forkel, Robert ({year}): **LingPy.  A Python library for historical linguistics**. Version {version}.  URL: http://lingpy.org, DOI: https://zenodo.org/badge/latestdoi/5137/lingpy/lingpy.  With contributions by {collaborators}. Jena: Max Planck Institute for the Science of Human History.  
 """.format(
         year=str(datetime.datetime.today()).split('-')[0],
         version=lingpy.__version__,

--- a/lingpy/algorithm/extra.py
+++ b/lingpy/algorithm/extra.py
@@ -8,12 +8,10 @@ from lingpy import log
 try:
     from sklearn import cluster
 except ImportError:
-    log.missing_module('sklearn')
     cluster = False
 try:
     import igraph
 except ImportError:
-    log.missing_module('igraph')
     igraph = False
 
 import numpy as np
@@ -60,6 +58,9 @@ def dbscan(
     
     Requires the scikitlearn package, downloadable from http://scikit-learn.org/.
     """
+    if not cluster:
+        raise ValueError("The package sklearn is needed to run this analysis.")
+
     if not taxa:
         taxa = list(range(1, len(matrix) + 1))
 
@@ -121,7 +122,8 @@ def affinity_propagation(threshold, matrix, taxa, revert=False):
 
     """
     if not cluster:
-        raise ValueError("The package scikitlearn is needed to run this analysis.")
+        raise ValueError("The package sklearn is needed to run this analysis.")
+
     if not taxa:
         taxa = list(range(1, len(matrix) + 1))
     # turn distances to similarities

--- a/lingpy/align/sca.py
+++ b/lingpy/align/sca.py
@@ -738,12 +738,12 @@ class Alignments(Wordlist):
             # the alignemnts
             for key in self:
                 # get the cognate IDs
-                cogids = self[key, rcParams['ref']]
+                cogids = self[key, ref]
                 # get the alignment
                 tmp[key] = []
                 for i, cogid in enumerate(cogids):
-                    if cogid in self.msa[rcParams['ref']]:
-                        msa = self.msa[rcParams['ref']][cogid]
+                    if cogid in self.msa[ref]:
+                        msa = self.msa[ref][cogid]
                         idx = msa['ID'].index(key)
                         tmp[key] += msa['alignment'][idx]
                     else:

--- a/lingpy/compare/lexstat.py
+++ b/lingpy/compare/lexstat.py
@@ -128,6 +128,50 @@ class LexStat(Wordlist):
         **False**.
     errors : str
         The name of the error log.
+    segments : str (default="tokens")
+        The name of the column in your data which contains the segmented
+        transcriptions, or in which the segmented transcriptions should be
+        placed. 
+    transcription : str (default="ipa")
+        The name of the column in your data which contains the unsegmented
+        transcriptions.
+    classes : str (default="classes")
+        The name of the column in the data which contains the sound class
+        representation of the transcriptions, or in which this information
+        shall be placed after automatic conversion.
+    numbers : str (default="numbers")
+        The language-specific triples consisting of language id (numeric),
+        sound class string (one character only), and prosodic string (one
+        character only). Usually, numbers are automatically created from
+        the columns "classes", "prostrings", and "langid", but you can also
+        provide them in your data.
+    langid : str (default="langid")
+        Name of the column that contains a numerical language identifier,
+        needed to produce the language-specific character triples ("numbers").
+        Unless specific explicitly, this is automatically created.
+    prostrings : str (default="prostrings")
+        Name of the column containing prosodic strings (see :evobib:`List2014d`
+        for more details) of the segmented transcriptions, containing one
+        character per prosodic string.  Prostrings add a contextual component
+        to phonetic sequences. They are automatically created, but can likewise
+        be submitted from the initial data.
+    weights : str (default="weights")
+        The name of the column which stores the individual gap-weights for each
+        sequence. Gap weights are positive floats for each segment in a string,
+        which modify the gap opening penalty during alignment. 
+    tokenize : function (default=:py:class:`~lingpy.sequence.sound_classes.ipa2tokens`)
+        The function which should be used to tokenize the entries in the column
+        storing the transcriptions in case no segmentation is provided by the
+        user.
+    get_prostring : function (default=:py:class:`~lingpy.sequence.sound_classes.prosodic_string`)
+        The function which should be used to create prosodic strings from the
+        segmented transcription data. If you want to completely ignore prosodic
+        strings in LexStat calculations, you could just pass the following
+        function::
+            
+            >>> lex = LexStat('inputfile.tsv', get_prostring=lambda x: ["x" for
+                y in x])
+
 
     Attributes
     ----------
@@ -203,7 +247,8 @@ class LexStat(Wordlist):
             "sonars" : "sonars",
             "langid" : "langid",
             "duplicates" : "duplicates",
-            "tokenize" : ipa2tokens
+            "tokenize" : ipa2tokens,
+            "get_prostring" : prosodic_string
         }
         kw.update(keywords)
 
@@ -269,7 +314,7 @@ class LexStat(Wordlist):
                 lambda x: [int(i) for i in tokens2class(
                     x, rcParams['art'], stress=rcParams['stress'])])
         if self._prostrings not in self.header:
-            self.add_entries(self._prostrings, self._sonars, lambda x: prosodic_string(x))
+            self.add_entries(self._prostrings, self._sonars, lambda x: kw['get_prostring'](x))
         # get sound class strings
         if self._classes not in self.header:
             self.add_entries(

--- a/lingpy/tests/sequence/test_sound_classes.py
+++ b/lingpy/tests/sequence/test_sound_classes.py
@@ -7,7 +7,8 @@ from nose.tools import assert_raises
 from lingpy.sequence.sound_classes import ipa2tokens, token2class, \
         tokens2class, prosodic_string, prosodic_weights, class2tokens, pid,\
         check_tokens, get_all_ngrams, sampa2uni, bigrams, trigrams, fourgrams,\
-        get_n_ngrams, pgrams, syllabify, tokens2morphemes, ono_parse
+        get_n_ngrams, pgrams, syllabify, tokens2morphemes, ono_parse,\
+        clean_string, _get_brackets
 from lingpy import rc, csv2list
 from six import text_type
 
@@ -208,3 +209,23 @@ def test_onoparse():
     assert isinstance(out1, text_type)
     assert out3[0] == ('-', '#')
     assert out2 == 'VCvcC>$'
+
+def test_clean_string():
+
+    seq1 = 'this (is an error)'
+    seq2 = 'feature/vector'
+    seq3 = 'ta:tata'
+    seq4 = 'what (the) hack [this is]'
+    seq5 = 't a t'
+
+    _get_brackets('A')
+
+    assert clean_string(seq1)[0] == 'th i s'
+    assert clean_string(seq2)[1] == 'v e c t o r'
+    assert clean_string(seq3)[0] == 't a: t a t a'
+    assert clean_string(seq4)[0] == 'wh a t _ h a c k'
+    assert clean_string(seq5, segmentized=True)[0] == 't a t'
+    assert clean_string('a(a', ignore_brackets=False)[0] == 'a ( a'
+    assert clean_string('a/a', split_entries=False)[0] == 'a / a'
+
+    


### PR DESCRIPTION
This new function is useful to clean the kind of data we usually get, it ignores stuff in brackets, splits, according to splitters (like comma, or / in the data), and segmentizes as good as possible.

```python

>>> from lingpy.sequence.sound_classes import clean_string
>>> clean_string('this is a / test')
['th i s _ i s _ a', 't e s t']
```