### PR TITLE
Fixing more typos

### DIFF
--- a/lingpy/align/pairwise.py
+++ b/lingpy/align/pairwise.py
@@ -287,7 +287,7 @@ def pw_align(
     --------
     Align two words using the dialign algorithm::
         >>> seqA = 'fat cat'
-        >>> setB = 'catfat'
+        >>> seqB = 'catfat'
         >>> pw_align(seqA, seqB, mode='dialign')
         (['f', 'a', 't', ' ', 'c', 'a', 't', '-', '-', '-'],
          ['-', '-', '-', '-', 'c', 'a', 't', 'f', 'a', 't'],
@@ -344,7 +344,7 @@ def nw_align(seqA, seqB, scorer=False, gap=-1):
     --------
 
     >>> seqA = 'fat cat'
-    >>> setB = 'catfat'
+    >>> seqB = 'catfat'
     >>> nw_align(seqA,seqB)
     (['f', 'a', 't', ' ', 'c', 'a', 't'], ['c', 'a', 't', '-', 'f', 'a', 't'], 1)
 
@@ -420,7 +420,7 @@ def edit_dist(seqA, seqB, normalized=False, restriction=''):
     Examples
     --------
     >>> seqA = 'fat cat'
-    >>> setB = 'catfat'
+    >>> seqB = 'catfat'
     >>> edit_dist(seqA, seqB)
     3
 
@@ -466,7 +466,7 @@ def sw_align(seqA, seqB, scorer=False, gap=-1):
     --------
 
     >>> seqA = 'fat cat'
-    >>> setB = 'catfat'
+    >>> seqB = 'catfat'
     >>> sw_align(seqA, seqB)
     (([], ['f', 'a', 't'], [' ', 'c', 'a', 't']),
      (['c', 'a', 't'], ['f', 'a', 't'], []),
@@ -509,7 +509,7 @@ def we_align(seqA, seqB, scorer=False, gap=-1):
     --------
 
     >>> seqA = 'fat cat'
-    >>> setB = 'catfat'
+    >>> seqB = 'catfat'
     >>> we_align(seqA, seqB)
     [(['f', 'a', 't'], ['f', 'a', 't'], 3.0),
      (['c', 'a', 't'], ['c', 'a', 't'], 3.0)]

--- a/lingpy/data/model.py
+++ b/lingpy/data/model.py
@@ -80,9 +80,8 @@ class Model(object):
     >>> dolgo = rc('dolgo')
     >>> art = rc('art')
 
-    Check, how the letter ``a`` is converted in the various models:
+    Check how the letter ``a`` is converted in the various models:
 
-    >>> for m in [asjp,sca,dolgo,art]:
     >>> for m in [asjp,sca,dolgo,art]:
     ...     print('{0} > {1} ({2})'.format('a',m.converter['a'],m.name))
     ...


### PR DESCRIPTION
I read all the docstrings and tried the example codes, there were still some typos. I didn't change the references to the cython modules (such as '_calign' for 'calign'), but perhaps these could be changed too.