### PR TITLE
provide consistency fix for profile generator

### DIFF
--- a/lingpy/cli.py
+++ b/lingpy/cli.py
@@ -346,6 +346,8 @@ class profile(Command):
         else:
             lingpy.util.write_text_file(args.output_file, out) 
 
+        return len(out)-1
+
 class lexstat(Command):
     @classmethod
     def subparser(cls, p):

--- a/lingpy/cli.py
+++ b/lingpy/cli.py
@@ -304,15 +304,18 @@ class profile(Command):
     def __call__(self, args):
         if args.cldf:
             wl = lingpy.basic.wordlist.get_wordlist(args.input_file,
-                    row='Parameter_name', col='Language_ID')
+                    row='Parameter_ID', col='Language_ID')
         else:
             wl = lingpy.basic.wordlist.Wordlist(args.input_file)
 
+        # check for count in string
+        count = 'NO\t' if args.count else ''
+
         if args.context:
-            out = ['Grapheme\tIPA\tEXAMPLES\tLANGUAGES\tFREQUENCY\tCODEPOINTS']
+            out = [count+'Grapheme\tIPA\tEXAMPLES\tLANGUAGES\tFREQUENCY\tCODEPOINTS']
             function = lingpy.sequence.profile.context_profile
         else:
-            out = ['Grapheme\tIPA\tFREQUENCY\tCODEPOINTS']
+            out = [count+'Grapheme\tIPA\tFREQUENCY\tCODEPOINTS']
             function = lingpy.sequence.profile.simple_profile
         if args.column.lower() not in wl.header:
             raise ValueError("Wrong column header specified!")
@@ -322,7 +325,7 @@ class profile(Command):
 
         if args.language:
             D = {0: [h for h in sorted(wl.header, key=lambda x: wl.header[x])]}
-            for idx in wl.get_list(col=argslanguage, flat=True):
+            for idx in wl.get_list(col=args.language, flat=True):
                 D[idx] = wl[idx]
             wl = lingpy.basic.wordlist.Wordlist(D)
         if args.context:
@@ -330,12 +333,14 @@ class profile(Command):
                     with_clts=args.clts):
                 out += ['\t'.join(line)]
         else:
-            for line in lingpy.sequence.profile.simple_profile(wl, ref=args.column):
+            for line in lingpy.sequence.profile.simple_profile(wl,
+                    ref=args.column, with_clts=args.clts):
                 out += ['\t'.join(line)]
         if args.output_file == 'stdout':
-            for i, line in enumerate(out):
+            print(out[0])
+            for i, line in enumerate(out[1:]):
                 if args.count:
-                    print(str(i)+'\t'+line)
+                    print(str(i+1)+'\t'+line)
                 else:
                     print(line)
         else:

--- a/lingpy/tests/test_cli.py
+++ b/lingpy/tests/test_cli.py
@@ -113,3 +113,10 @@ class Tests(WithTempDir):
                                   test_data('KSL.qlc'),
                                   '--output-file', self.tmp_path('lexstat').as_posix())
         assert cogs == 1080
+
+    def test_profile(self):
+        prf = main('profile', '-i', test_data('KSL.qlc'), '--column', 'ipa')
+        assert prf == 105
+        prf = main('profile', '-i', test_data('KSL.qlc'), '--column', 'ipa',
+                '--language', 'German', '--count')
+        assert prf == 37


### PR DESCRIPTION
this is important, as it allows us now to use ```lexibank``` cldf-files to create a first ortho-profile, e.g., using the "count" keyword to simply count the number of characters:

```shell
$ cd lexibank-data/datasets/baidial/
$ lingpy profile -i forms.csv --count --cldf --column=form --clts
NO	Grapheme	IPA	FREQUENCY	CODEPOINTS
1	⁵⁵	⁵⁵	1297	U+2075 U+2075
2	³³	³³	1192	U+00b3 U+00b3
3	⁴⁴	⁴⁴	1131	U+2074 U+2074
4	a	a	979	U+0061
5	u	u	853	U+0075
6	³¹	³¹	844	U+00b3 U+00b9
...
67	ʧʰ	tʃʰ	13	U+02a7 U+02b0
68	xʰ	xʰ	12	U+0078 U+02b0
69	ʊ	ʊ	12	U+028a
70	ʅ	ʅ	10	U+0285
71	tʂʰ	ʈʂʰ	10	U+0074 U+0282 U+02b0
72	c	c	9	U+0063
73	ỹ	ỹ	9	U+1ef9
74	ɕʰ	ɕʰ	9	U+0255 U+02b0
75	ʥ	dʑ	8	U+02a5
76	ɴ	ɴ	7	U+0274
77	ʈʰ	ʈʰ	7	U+0288 U+02b0
78	ʑ	ʑ	6	U+0291
79	ɴ̣	!ɴ̣	6	U+0274 U+0323
80	ɖ	ɖ	5	U+0256
81	kʲʰ	kʰʲ	5	U+006b U+02b2 U+02b0
...
```

Note the option ```--clts``` which converts the characters in the IPA column automatically (I added a few more lines below, see 81, also 67, 71, and 79 as an example for an "unknown sound".
