### PR TITLE
Dead requirements file

### DIFF
--- a/pip-requirements
+++ b/pip-requirements
@@ -1,4 +1,0 @@
-appdirs
-numpy>=1.4.0
-networkx>=2.0
-matplotlib>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 appdirs
-networkx
+networkx>=2.0
+matplotlib>=1.3.0
 clldutils>=1.6
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ networkx>=2.0
 matplotlib>=1.3.0
 clldutils>=1.6
 tqdm
+six

--- a/setup.py
+++ b/setup.py
@@ -59,14 +59,12 @@ if 'install' in sys.argv or 'bdist_egg' in sys.argv or 'develop' in sys.argv:
 else:
     extension_modules = []
 
-requires = [
-    'networkx',
-    'numpy',
-    'six',
-    'appdirs',
-    'clldutils>=1.5.1',
-    'tqdm',
-]
+# load requirements
+if os.path.isfile('requirements.txt'):
+    with open('requirements.txt', 'r') as handle:
+        requires = [_.strip() for _ in handle.readlines() if len(_.strip())]
+else:
+    requires = []
 
 # make global name of this version for convenience of modifying it
 thisversion = "2.5"


### PR DESCRIPTION
The file [pip-requirements](https://github.com/lingpy/lingpy/blob/master/pip-requirements) seems to be dead? the standard is requirements.txt (which exists) and it has an odd version number in it (numpy>=1.4.0 -- current version is 1.13).