### PR TITLE
Updated requirements for tutorial.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ matplotlib>=1.3.0
 clldutils>=1.6
 tqdm
 six
+pycldf
+segments


### PR DESCRIPTION
Didn't add python-newick (not on repositories) and python-igraph (yet, have to guarantee that compiles). `pycldf` might require Python development libraries installed, is that ok?