### PR TITLE
Provide a semantically meaningful way of saying 'there are no' (=None) comments.

### DIFF
--- a/lingpy/read/csv.py
+++ b/lingpy/read/csv.py
@@ -67,7 +67,7 @@ def csv2list(
     idx = 0 if header else -1
 
     for i, line in enumerate(infile):
-        if line and not line.startswith(comment) and idx != i:
+        if line and (not line.startswith(comment) if comment else True) and idx != i:
             if strip_lines:
                 cells = [c.strip() for c in line.strip().split(sep)]
             else:


### PR DESCRIPTION
(instead of, e.g., entering a random string [or some other technique I haven't noted?]). Additionally, it might also be considered to assume None as default for comment to avoid unintended side-effects.