### PR TITLE
Fixing bug in token2class() for empty strings.

### DIFF
--- a/lingpy/sequence/sound_classes.py
+++ b/lingpy/sequence/sound_classes.py
@@ -20,18 +20,18 @@ from lingpy.data.ipa.sampa import reXS, xs
 def ipa2tokens(istring, **keywords):
     """
     Tokenize IPA-encoded strings.
-    
+
     Parameters
     ----------
 
     seq : str
         The input sequence that shall be tokenized.
-    
+
     diacritics : {str, None} (default=None)
         A string containing all diacritics which shall be considered in the
         respective analysis. When set to *None*, the default diacritic string
         will be used.
-    
+
     vowels : {str, None} (default=None)
         A string containing all vowel symbols which shall be considered in the
         respective analysis. When set to *None*, the default vowel string will
@@ -51,7 +51,7 @@ def ipa2tokens(istring, **keywords):
         starts right after them. These can be used to indicate that two
         consecutive vowels should not be treated as diphtongs or for diacritics
         that are put before the following letter.
-    
+
     merge_vowels : bool (default=False)
         Indicate, whether vowels should be merged into diphtongs
         (default=True), or whether each vowel symbol should be considered
@@ -84,7 +84,7 @@ def ipa2tokens(istring, **keywords):
     >>> myseq = 't͡sɔyɡə'
     >>> ipa2tokens(myseq)
     ['t͡s', 'ɔy', 'ɡ', 'ə']
-    
+
     See also
     --------
     tokens2class
@@ -239,7 +239,7 @@ def ipa2tokens(istring, **keywords):
 def syllabify(seq, output="flat", **keywords):
     """
     Carry out a simple syllabification of a sequence, using sonority as a proxy.
-    
+
     Parameters
     ----------
     output: {"flat", "breakpoints", "nested"} (default="flat")
@@ -247,10 +247,10 @@ def syllabify(seq, output="flat", **keywords):
         * "flat": A syllable separator is introduced to mark the syllable boundaries
         * "breakpoins": A tuple consisting of indices that slice the original sequence into syllables is returned.
         * "nested": A nested list reflecting the syllable structure is returned.
-          
+
     sep : str (default="◦")
         Select your preferred syllable separator.
-    
+
     Notes
     -----
 
@@ -400,7 +400,7 @@ def tokens2morphemes(tokens, **keywords):
         Select your morpheme separator.
     word_sep: str (default="_")
         Select your word separator.
-    
+
     Returns
     -------
     morphemes : list
@@ -444,7 +444,7 @@ def tokens2morphemes(tokens, **keywords):
 def _split_syllables(syllables, tokens):
     """
     Split the output of the syllabify method into subsets.
-    
+
     Notes
     -----
     This is a simple helper function to deal with syllabified content.
@@ -486,7 +486,7 @@ def _pprint_ono(ono):
 def ono_parse(word, output='', **keywords):
     """
     Carry out a rough onset-nucleus-offset parse of a word in IPA.
-    
+
     Notes
     -----
     Method is an approximation and not supposed to do without flaws. It is,
@@ -645,7 +645,7 @@ def token2class(token, model, stress=None, diacritics=None, cldf=None):
     # check basic parameters
     stress = rcParams['stress'] or stress
     diacritics = rcParams['diacritics'] or diacritics
-    
+
     # change token if cldf is selected
     if cldf:
         token = token.split('/')[1] or '?' if '/' in token else token
@@ -653,12 +653,14 @@ def token2class(token, model, stress=None, diacritics=None, cldf=None):
     # check whether model is passed as real model or as string
     if str(model) == model:
         model = rcParams[model]
-    
+
     try:
         return model[token]
     except KeyError:
         try:
             return model[token[0]]
+        except IndexError:
+            return '0'
         except KeyError:
             # check for stressed syllables
             if len(token) > 0:
@@ -721,7 +723,7 @@ def tokens2class(tokens, model, stress=None, diacritics=None, cldf=False):
         in a reconstruction system, and the target is a proposed phonetic
         interpretation. This practice is also accepted by the `EDICTOR
         <http://edictor.digling.org>`_ tool.
-        
+
     Returns
     -------
 
@@ -737,7 +739,7 @@ def tokens2class(tokens, model, stress=None, diacritics=None, cldf=False):
     an unknown sound in a longer sequence is no problem for alignment
     algorithms, we have some unwanted and often even unforeseeable behavior,
     if the sequence is completely unknown. For this reason, this function
-    raises a ValueError, if a resulting sequence only contains unknown sounds. 
+    raises a ValueError, if a resulting sequence only contains unknown sounds.
 
     Examples
     --------
@@ -809,19 +811,19 @@ def prosodic_string(string, _output=True, **keywords):
 
     See also:
     ---------
-    
+
     prosodic weights
 
     Notes
     -----
-    
+
     A prosodic string is a sequence of specific characters which indicating
     their resprective prosodic context (see :evobib:`List2012` or
     :evobib:`List2012a` for a detailed description).
     In contrast to the previous model, the current implementation allows for a
     more fine-graded distinction between different prosodic segments. The
     current scheme distinguishes 9 prosodic positions:
-    
+
     * ``A``: sequence-initial consonant
     * ``B``: syllable-initial, non-sequence initial consonant in a context of
       ascending sonority
@@ -999,7 +1001,7 @@ def prosodic_string(string, _output=True, **keywords):
 def prosodic_weights(prostring, _transform={}):
     """
     Calculate prosodic weights for each position of a sequence.
-    
+
     Parameters
     ----------
 
@@ -1028,7 +1030,7 @@ def prosodic_weights(prostring, _transform={}):
     >>> prostring = '#vC>'
     >>> prosodic_weights(prostring)
     [2.0, 1.3, 1.5, 0.7]
-    
+
     See also
     --------
     prosodic_string
@@ -1116,11 +1118,11 @@ def class2tokens(tokens, classes, gap_char='-', local=False):
 
     gap_char : string (default="-")
         The character which indicates gaps in the output string.
-    
+
     local : bool (default=False)
         If set to *True* a local alignment with prefix and suffix can be
         converted.
-    
+
     Returns
     -------
     alignment : list
@@ -1131,7 +1133,7 @@ def class2tokens(tokens, classes, gap_char='-', local=False):
     --------
     ipa2tokens
     tokens2class
-    
+
     Examples
     --------
     >>> from lingpy import *
@@ -1180,13 +1182,13 @@ def pid(almA, almB, mode=2):
         Indicate which of the four possible PID scores described in :evobib:`Raghava2006`
         should be calculated, the fifth possibility is added for linguistic
         purposes:
-        
+
         1. identical positions / (aligned positions + internal gap positions),
-        
+
         2. identical positions / aligned positions,
-        
+
         3. identical positions / shortest sequence, or
-        
+
         4. identical positions / shortest sequence (including internal gap
            pos.)
 
@@ -1201,7 +1203,7 @@ def pid(almA, almB, mode=2):
 
     Notes
     -----
-    
+
     The PID score is a common measure for the diversity of a given alignment.
     The implementation employed by LingPy follows the description of
     :evobib:`Raghava2006` where four different variants of PID scores are
@@ -1492,9 +1494,9 @@ def clean_string(
         entry. If there are no splitters, the list has only size one.
     """
     sequence = unicodedata.normalize(normalization_form, sequence)
-    rules = rules or {} 
+    rules = rules or {}
     preparse = preparse or []
-    
+
     # replace white space if not indicated otherwise
     if segmentized:
         segment_list = [sequence.split(' ') if not isinstance(sequence, (list,
@@ -1517,7 +1519,7 @@ def clean_string(
 
         for new_sequence in new_sequences:
             segments = ipa2tokens(
-                    re.sub(r'\s+', '_', new_sequence.strip()), 
+                    re.sub(r'\s+', '_', new_sequence.strip()),
                     semi_diacritics=semi_diacritics,
                     merge_vowels=merge_vowels,
                     merge_geminates=merge_geminates)

--- a/lingpy/tests/sequence/test_sound_classes.py
+++ b/lingpy/tests/sequence/test_sound_classes.py
@@ -1,4 +1,4 @@
-# *-* coding: utf-8 *-* 
+# *-* coding: utf-8 *-*
 from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
@@ -23,34 +23,34 @@ def test_ipa2tokens():
     assert len(ipa2tokens(seq)) != len(list(seq))
 
     seq = 'ʰto͡i'
-    
+
     assert len(ipa2tokens(seq)) == 2
 
     seq = 'th o x t a'
-    
+
     assert len(ipa2tokens(seq)) == len(seq.split(' '))
 
     seq = '# b l a #'
-    
+
     assert len(ipa2tokens(seq)) == len(seq.split(' '))-2
 
     # now check with all possible data we have so far, but only on cases where
     # tokenization doesn't require the merge_vowels = False flag
     tokens = csv2list(test_data('test_tokenization.tsv'))
-    
+
     for a,b in tokens:
-        
+
         tks = ' '.join(ipa2tokens(a))
 
         # we check for two variants, since we don't know whether vowels are
         # merged or not in the test data
         assert tks == b
 
-    # now test on smaller set with unmerged vowels 
+    # now test on smaller set with unmerged vowels
     tokens = csv2list(test_data('test_tokenization_mv.tsv'))
-    
+
     for a,b in tokens:
-        
+
         tks = ' '.join(ipa2tokens(a, merge_vowels=False, merge_geminates=False))
 
         # we check for two variants, since we don't know whether vowels are
@@ -70,6 +70,7 @@ def test_token2class():
     assert token2class(seq[0], rc('dolgo')) == 'T'
     assert token2class(seq[3], 'dolgo') == 'T'
     assert token2class(seq[-1], 'dolgo') == '0'
+    assert token2class('', 'dolgo') == '0'
 
 def test_tokens2class():
 
@@ -82,7 +83,6 @@ def test_tokens2class():
     assert tokens2class(seq2, 'cv', cldf=True)[2] == 'C'
     assert tokens2class(seq3, 'cv', cldf=True)[2] == '0'
 
-    assert_raises(IndexError, tokens2class, 'b  l'.split(' '), 'dolgo')
     assert_raises(ValueError, tokens2class, ['A'], 'dolgo')
     assert_raises(ValueError, tokens2class, 'bla', 'sca')
 
@@ -92,7 +92,7 @@ def test_prosodic_string():
     seq = 'tʰ ɔ x t ə r'.split(' ')
 
     assert prosodic_string(seq) == 'AXMBYN'
-    
+
     seq = 'th o x ¹ t e'.split(' ')
 
     assert prosodic_string(seq) == 'AXLTBZ'
@@ -143,7 +143,7 @@ def test_check_tokens():
     assert check_tokens('th o x T e r'.split(' '))[0] == (3,'T')
 
 def test_get_all_ngrams():
-    
+
     f = get_all_ngrams('ab')
     assert f == ['ab', 'a', 'b']
 
@@ -154,7 +154,7 @@ def test_sampa2uni():
     assert sampa == seq #or sampa2 == seq
 
 def test_bigrams():
-    
+
     f = bigrams('ab')
     assert f[0] == ('#','a') and f[-1] == ('b','$')
 
@@ -168,19 +168,19 @@ def test_fourgrams():
     assert f[-1] == ('b','$','$','$')
 
 def test_get_n_ngrams():
-    
+
     f = get_n_ngrams('ma',5)
 
     assert f[0] == ('m','a','$','$','$')
 
 def test_pgrams():
-    
+
     f = pgrams('ab')
     assert f[0] == ('a','X')
     assert f[-1] == ('b','N')
 
 def test_syllabify():
-    
+
     seq1 = "t i a o ¹ b u ² d a o"
     seq2 = "jabloko"
     seq3 = "jabəlko"
@@ -215,7 +215,7 @@ def test_onoparse():
     out1 = ono_parse(seq1, output='pprint')
     out2 = ono_parse(seq2, output='prostring')
     out3 = ono_parse(seq1)
-   
+
     assert isinstance(out1, text_type)
     assert out3[0] == ('-', '#')
     assert out2 == 'VCvcC>$'


### PR DESCRIPTION
Fixes bug in token2class(), as reported [in issue #320 ](https://github.com/lingpy/lingpy/issues/320)

Please note that the fix actually break a test that was asserting precisely whether IndexError was raised with an empty string (was it once the intended behavior?). I removed this test and added a new one.