### PR TITLE
Fixes bug in ipa2tokens() when a sequence starts with a combiner.

### DIFF
--- a/lingpy/sequence/sound_classes.py
+++ b/lingpy/sequence/sound_classes.py
@@ -149,8 +149,18 @@ def ipa2tokens(istring, **keywords):
 
         # check for combiners next
         elif char in kw['combiners']:
-            out[-1] += char
-            merge = True
+            # add the combiner to the previous entry in `out`; if there
+            # is no previous characters (i.e., sequence starts with a 
+            # combiner, which is something we perhaps should not accept, see
+            # discussion on issue #365 on GitHub), append the combiner to
+            # a null phoneme glyph
+            if not out:
+                # empty list, i.e., no previous entry
+                out = ['\u2205' + char]
+                merge = False
+            else:
+                out[-1] += char
+                merge = True
 
         # check for stress
         elif char in kw['stress']:


### PR DESCRIPTION
This fixes the bug discussed [here](https://github.com/lingpy/lingpy/issues/365). The new behaviour is demonstrated here:

```python
In [1]: import lingpy

In [2]: test = b'\\u0361w\\u0254\\u031e\\u02d1t'.decode('unicode_escape')

In [3]: test
Out[3]: '͡wɔ̞ˑt'

In [4]: lingpy.ipa2tokens(test)
Out[4]: ['∅͡', 'w', 'ɔ̞ˑ', 't']
```

Two things:

- For the time being, it is joining the initial combinator with the null phoneme, as in the example above. It seems must (all?) of us agree that it should fail, throwing a `ValueError` exception with enough information so one can immediately understand the problem (especially valid since it can be difficult to catch an initial combinator by eye); we can easily change this if agreed.
- This is *not* implementing a test for the new `ipa2tokens()` behaviour, as @chrzyki is rewriting the tests. It can either be done later or we can wait so I write a proper test later, as this bug-fix is not urgent. In any case, there is no direct `ipa2tokens()` test in `master` at the moment, the function is only tested as part of `align/test_sca` and `sequence/test_sound_classes`.