### PR TITLE
Fixes bug with cognateset

### DIFF
--- a/lingpy/basic/wordlist.py
+++ b/lingpy/basic/wordlist.py
@@ -1059,7 +1059,8 @@ class Wordlist(QLCParserWithRowsAndCols):
                 'concept_concepticon_id',
                 'language_latitude',
                 'language_longitude',
-                'cognacy'
+                'cognacy',
+                'cogid_cognateset_id',
                 ),
             namespace=(
                ('concept_name', 'concept'),


### PR DESCRIPTION
Pull request #407 has a bug that prevents using `cogid_cognateset_id` directly, as the column name is missing from the default `columns` parameter.

This small PR fixes the bug and allows to use CLDF datasets directly.