### PR TITLE
major update for partial cognate detection, deleting pickle behavior …

### DIFF
--- a/lingpy/basic/parser.py
+++ b/lingpy/basic/parser.py
@@ -51,12 +51,6 @@ class QLCParser(object):
 
     """
 
-    @staticmethod
-    def unpickle(filename):
-        obj = cache.load(filename)
-        obj._recreate_unpicklables()
-        return obj
-
     def __init__(self, filename, conf=''):
         """
         Parse data regularly if the data has not been loaded from a pickled version.
@@ -189,11 +183,6 @@ class QLCParser(object):
         for key in [k for k in input_data if type(k) != int]:
             self._meta[key] = input_data[key]
 
-    def _recreate_unpicklables(self):
-        """run `eval` on the string representations."""
-        self.log = log.get_logger()
-        self._class = {key: eval(value) for key, value in self._class_string.items()}
-
     def __getitem__(self, idx):
         """
         Method allows quick access to the data by passing the integer key.
@@ -287,27 +276,6 @@ class QLCParser(object):
         """
 
         return iter([key for key in self._data.keys()])
-
-    def pickle(self, filename=None):
-        """
-        Store the QLCParser instance in a pickle file.
-
-        Notes
-        -----
-        The function stores a binary file called ``FILENAME.pkl`` with ``FILENAME``
-        corresponding to the name of the original file in the
-        `user cache dir <https://github.com/ActiveState/appdirs#some-example-output>`_
-        for lingpy on your system.
-        To restore the instance from the pickle call
-        :py:meth:`~lingpy.basic.parser.QLCParser.unpickle`.
-        """
-        # we reset the _class attribute, because it may contain unpicklable stuff, like
-        # `eval`ed lambdas.
-        self._class = {}
-        self.log = None
-        cache.dump(self, filename or self.filename)
-        # after pickling we have to recreate the attribute.
-        self._recreate_unpicklables()
 
     def add_entries(
             self,

--- a/lingpy/basictypes.py
+++ b/lingpy/basictypes.py
@@ -63,7 +63,7 @@ class lists(_strings):
         return lists(str(self)+self.sep+str(other))
 
     def extend(self, other):
-        super(lists, self).extend(lists('')+other)
+        super(lists, self).extend(lists('')+_strings(str, other))
 
     def change(self, i, item):
         self.n[i] = _strings(str, item)

--- a/lingpy/compare/_structure.py
+++ b/lingpy/compare/_structure.py
@@ -1,0 +1,101 @@
+from __future__ import division
+from lingpy.sequence.sound_classes import tokens2class, prosodic_string, tokens2morphemes
+from lingpy.align.multiple import mult_align
+from collections import defaultdict
+from itertools import combinations
+
+def _scorer():
+    scoredict = {}
+    for c1, c2 in combinations(list('CcVvT'), r=2):
+        scoredict[c1, c2] = 0
+        scoredict[c2, c1] = 0
+    for c in 'CcVvT':
+        scoredict[c, c] = 5
+    return scoredict
+
+def pattern_consensus(patterns, scoredict):
+
+    alms = mult_align(patterns, 
+            scoredict=scoredict)
+    cons = []
+    for j in range(len(alms[0])):
+        col = [alms[i][j] for i in range(len(alms))]
+        sounds = sorted(
+                set([x for x in col if x != '-']), 
+                key=lambda x: col.count(x)) 
+        token = '|'.join(sounds)
+        if '-' in col:
+            cons += ['('+token+')']
+        else:
+            cons += [token]
+    return cons
+
+def cv_templates(
+        wordlist, language, segments='tokens', converter=None, cutoff=0.1,
+        output='markdown', examples=3, scoredict=None, splitter=False
+        ):
+    """Create CV templates from wordlist data."""
+    templates = defaultdict(list)
+    idxs = wordlist.get_list(col=language, flat=True)
+    sounds = defaultdict(list)
+
+    def str_(list_):
+        return ', '.join([' '.join(l) for l in list_[:examples]])
+    
+    if not converter:
+        converter = lambda x: prosodic_string(x, _output='CcV') 
+    scoredict = scoredict or _scorer()
+    if not splitter:
+        splitter = lambda x: filter(None, tokens2morphemes(x))
+
+    for idx in idxs:
+        segs = wordlist[idx, segments]
+        for word in splitter(segs):
+            cv = converter(word)
+            templates[cv] += [word]
+            for sound, symbol in zip(word, cv):
+                 sounds[sound, symbol] += [word]
+
+    # retrieve percentile 
+    lengths = sum([len(v) for v in templates.values()])
+    perc = lengths - (cutoff * lengths)
+    
+    patterns, ignored = [], []
+    score = 0
+    for k, v in sorted(templates.items(), key=lambda x: len(x[1]), reverse=True):
+        l = len(v)
+        if score + l > perc:
+            ignored += [[k, l, v]]
+        else:
+            patterns += [[k, l, v]]
+        score += l
+    
+    # compute pattern consensus
+    consensus = pattern_consensus([list(p[0]) for p in patterns], scoredict)
+
+    # extract initials
+    sound_table = []
+    for k, v in sorted(sounds.items(), key=lambda x: (x[0][1], len(x[1]))):
+        sound_table += [(k[0], k[1], len(v), v)]
+        
+    if output == 'markdown':
+        out = 'Pattern | Frequency | Examples\n --- | --- | --- \n'
+        score = 0
+        for i, (p, l, v) in enumerate(patterns):
+            out += '{0:15} | {1:5} | {2}\n'.format(p, l, str_(v))
+            score += l
+        count = 1
+        out += '\nSound | Context | Frequency | Examples\n --- | --- | --- | --- \n'
+        for sound, context, l, vals in sound_table:
+            out += '{0} | {1} | {2} | {3} \n'.format(
+                sound, context, l, str_(vals))
+            
+        out += '\n* **coverage:** {0} out of {1} patterns in the data\n'.format(
+                score, lengths)
+        out += '* **pattern consensus:** {0}\n'.format(' '.join(consensus))
+        return out
+
+    return patterns, ignored, sound_table
+
+    
+

--- a/lingpy/tests/basic/test_parser.py
+++ b/lingpy/tests/basic/test_parser.py
@@ -63,19 +63,6 @@ class TestParser(TestCase):
                                           'concept', 'cogid', {})
         assert parser.cogid
 
-    def test_cache(self):
-        filename = 'lingpy_test.qlc'
-        self.parser.pickle(filename=filename)
-        from_cache = QLCParser.unpickle(filename)
-        self.assertEqual(self.parser.header, from_cache.header)
-        os.remove(str(path(filename)))
-
-        wl = Wordlist(test_data('KSL.qlc'))
-        wl.pickle(filename=filename)
-        from_cache = Wordlist.unpickle(filename)
-        self.assertTrue(from_cache._class)
-        os.remove(str(path(filename)))
-
     def test_len(self):
         assert len(self.parser)
 

--- a/lingpy/tests/compare/test_partial.py
+++ b/lingpy/tests/compare/test_partial.py
@@ -24,6 +24,9 @@ class Tests(WithTempDir):
         assert a[0][1] == 3
         assert b[0][1] == 6
 
+    def test_get_partial_scorer(self):
+        self.part2.get_partial_scorer(runs=10)
+
     def test_get_partial_matrices(self):
         for method in ['upgma', 'single', 'complete', 'ward', 'mcl']:
             matrix = list(self.part._get_partial_matrices(cluster_method=method,


### PR DESCRIPTION
…of wordlists

This update for partial cognates is important, as it corrects for quite some aspects of the code, specifically allowing for an individual scorer for partial cognates, where the lexstat scorer is no loner recycled. Code is redundant in this part, but this may be addressed at a later stage. So far, it seems to pass all tests.