### PR TITLE
Fixes #423 (Do not re-segment in ipa2tokens when being passed a list-like object)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "appdirs",
         "networkx>=2.3",
         "tqdm",
-        'csvw>=1.5.6"',
+        'csvw>=1.5.6',
         'clldutils>=2.8.0',
         'pycldf>=1.7.0',
     ],

--- a/src/lingpy/evaluate/alr.py
+++ b/src/lingpy/evaluate/alr.py
@@ -84,8 +84,11 @@ def mean_edit_distance(
         log.debug('{0}, {1}'.format(proto, consensus))
 
         if tokens or classes:
-            proto = ipa2tokens(proto, **keywords)
-            consensus = ipa2tokens(consensus, **keywords)
+            # Only tokenize proto and consensus if not yet tokenized
+            if not isinstance(proto, list):
+                proto = ipa2tokens(proto, **keywords)
+            if not isinstance(consensus, list):
+                consensus = ipa2tokens(consensus, **keywords)
 
             if classes:
                 proto = tokens2class(proto, keywords['model'], stress=keywords['stress'],

--- a/src/lingpy/evaluate/alr.py
+++ b/src/lingpy/evaluate/alr.py
@@ -13,8 +13,6 @@ def mean_edit_distance(
         gold="proto",
         test="consensus",
         ref="cogid",
-        tokens=True,
-        classes=False,
         **keywords):
     """
     Function computes the edit distance between gold standard and test set.
@@ -82,22 +80,6 @@ def mean_edit_distance(
         consensus = wordlist[idx, test]
 
         log.debug('{0}, {1}'.format(proto, consensus))
-
-        if tokens or classes:
-            # Only tokenize proto and consensus if not yet tokenized
-            if not isinstance(proto, list):
-                proto = ipa2tokens(proto, **keywords)
-            if not isinstance(consensus, list):
-                consensus = ipa2tokens(consensus, **keywords)
-
-            if classes:
-                proto = tokens2class(proto, keywords['model'], stress=keywords['stress'],
-                        diacritics=keywords['diacritics'],
-                        cldf=keywords['cldf'])
-                consensus = tokens2class(consensus, keywords['model'],
-                        stress=keywords['stress'],
-                        diacritics=keywords['diacritics'],
-                        cldf=keywords['cldf'])
 
         distances.append(edit_dist(proto, consensus, normalized=False))
 

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -105,6 +105,10 @@ def ipa2tokens(istring: str, **keywords):
     if kw['clean_sequence']:
         raise ValueError("This part has not yet been implemented!")
 
+    # check if input is a string
+    if not isinstance(istring, str):
+        raise ValueError("Input must be a string")
+
     # check for pre-tokenized strings
     if ' ' in istring:
         out = istring.split(' ')
@@ -112,10 +116,6 @@ def ipa2tokens(istring: str, **keywords):
             return out[1:-1]
         else:
             return out
-
-    # check for pre-tokenized lists and tuples
-    if isinstance(istring, (list, tuple)):
-        return list(istring)
 
     # create the list for the output
     out = []

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -48,12 +48,12 @@ def ipa2tokens(istring, **keywords):
         consecutive vowels should not be treated as diphtongs or for diacritics
         that are put before the following letter.
 
-    merge_vowels : bool (default=False)
-        Indicate, whether vowels should be merged into diphtongs
-        (default=True), or whether each vowel symbol should be considered
+    merge_vowels : bool (default=True)
+        Indicate, whether vowels should be merged into diphtongs,
+        or whether each vowel symbol should be considered
         separately.
 
-    merge_geminates : bool (default=False)
+    merge_geminates : bool (default=True)
         Indicate, whether identical symbols should be merged into one token, or
         rather be kept separate.
 
@@ -112,6 +112,10 @@ def ipa2tokens(istring, **keywords):
             return out[1:-1]
         else:
             return out
+
+    # check for pre-tokenized lists and tuples
+    if isinstance(istring, (list, tuple)):
+        return list(istring)
 
     # create the list for the output
     out = []
@@ -1503,5 +1507,3 @@ def clean_string(
 def codepoint(s):
     "Return unicode codepoint(s) for a character set."
     return ' '.join(['U+'+('000'+hex(ord(x))[2:])[-4:] for x in s])
-
-

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -13,7 +13,7 @@ from lingpy.settings import rcParams
 from lingpy.data.ipa.sampa import reXS, xs
 
 
-def ipa2tokens(istring, **keywords):
+def ipa2tokens(istring: str, **keywords):
     """
     Tokenize IPA-encoded strings.
 

--- a/tests/sequence/test_sound_classes.py
+++ b/tests/sequence/test_sound_classes.py
@@ -23,6 +23,9 @@ def test_ipa2tokens(test_data):
     seq = '# b l a #'
     assert len(ipa2tokens(seq)) == len(seq.split(' ')) - 2
 
+    seq = ['t͡s', 'ɔ', 'y', 'ɡ', 'ə']
+    assert len(ipa2tokens(seq)) == len(seq)
+
     # now check with all possible data we have so far, but only on cases
     # where tokenization doesn't require the merge_vowels = False flag
     tokens = csv2list(str(test_data / 'test_tokenization.tsv'))

--- a/tests/sequence/test_sound_classes.py
+++ b/tests/sequence/test_sound_classes.py
@@ -23,8 +23,9 @@ def test_ipa2tokens(test_data):
     seq = '# b l a #'
     assert len(ipa2tokens(seq)) == len(seq.split(' ')) - 2
 
-    seq = ['t͡s', 'ɔ', 'y', 'ɡ', 'ə']
-    assert len(ipa2tokens(seq)) == len(seq)
+    with pytest.raises(ValueError):
+        seq = ['t͡s', 'ɔ', 'y', 'ɡ', 'ə']
+        ipa2tokens(seq)
 
     # now check with all possible data we have so far, but only on cases
     # where tokenization doesn't require the merge_vowels = False flag


### PR DESCRIPTION
This PR fixes issue #423 by checking if the input `istring` variable is an instance of `list` or `tuple` and returning `istring` as a `list` if that is the case.

It also fixes a typo in the `setup.py` that prevented the tests from running and updated the docstring (default values for `merge_vowels` and `merge_geminates` were incorrect).