### PR TITLE
Fixes #443: ipa2tokens raises error when being passed string with spaces

### DIFF
--- a/src/lingpy/align/multiple.py
+++ b/src/lingpy/align/multiple.py
@@ -38,13 +38,6 @@ class Multiple:
 
     def __init__(self, seqs, **keywords):
         self.log = log.get_logger()
-        # store input sequences, check whether tokens or strings are passed
-        if isinstance(seqs[0], (list, tuple)):
-            self.seqs = [' '.join(s) for s in seqs]
-            self.tokens = [s for s in seqs]
-        else:
-            self.seqs = seqs
-            self.tokens = []
 
         # define a tokenizer function for convenience
         kw = {
@@ -59,20 +52,21 @@ class Multiple:
         }
         kw.update(keywords)
 
-        self.numbers = []
-        if self.tokens:
-            for i, tokens in enumerate(self.tokens):
-                self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
+        # store input sequences, check whether tokens or strings are passed
+        if isinstance(seqs[0], (list, tuple)):
+            self.seqs = [' '.join(s) for s in seqs]
+            self.tokens = [s for s in seqs]
         else:
-            # create a numerical representation of all sequences which reflects the
-            # order of both their position and the position of their tokens. Before
-            # this can be done, a tokenized version of all sequences has to be
-            # created
-            for i, seq in enumerate(self.seqs):
-                # check for pre-tokenized strings
-                tokens = seq.split() if ' ' in seq else ipa2tokens(seq, **kw)
-                self.tokens.append(tokens)
-                self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
+            self.seqs = seqs
+            self.tokens = [seq.split() if ' ' in seq else ipa2tokens(seq, **kw) for seq in seqs]
+
+        # create a numerical representation of all sequences which reflects the
+        # order of both their position and the position of their tokens. Before
+        # this can be done, a tokenized version of all sequences has to be
+        # created
+        self.numbers = []
+        for i, tokens in enumerate(self.tokens):
+            self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
 
         self.uniseqs = defaultdict(list)
         self.unique_seqs = kw["unique_seqs"]

--- a/src/lingpy/align/multiple.py
+++ b/src/lingpy/align/multiple.py
@@ -70,7 +70,7 @@ class Multiple:
             # created
             for i, seq in enumerate(self.seqs):
                 # check for pre-tokenized strings
-                tokens = ipa2tokens(seq, **kw)
+                tokens = seq.split() if ' ' in seq else ipa2tokens(seq, **kw)
                 self.tokens.append(tokens)
                 self.numbers.append([dotjoin(i + 1, j + 1) for j in range(len(tokens))])
 

--- a/src/lingpy/convert/html.py
+++ b/src/lingpy/convert/html.py
@@ -425,10 +425,13 @@ def msa2html(
         for i in msa['local']:
             local[i] = '*'
 
+    tokens = msa['seqs']
+    msa['seqs'] = [' '.join(seq) for seq in msa['seqs']]
+
     # get two sorting schemas for the sequences
     if keywords['class_sort']:
 
-        classes = [tokens2class(ipa2tokens(seq), rcParams['asjp']) for seq in msa['seqs']]
+        classes = [tokens2class(seq, rcParams['asjp']) for seq in tokens]
         seqs = dict(
             [(a[1], b) for a, b in zip(
                 sorted(

--- a/src/lingpy/read/qlc.py
+++ b/src/lingpy/read/qlc.py
@@ -171,7 +171,7 @@ def _list2msa(msa_lines, ids=False, header=True, normalize=False, **keywords):
             else:
                 d["ID"] += [i]
             d["taxa"] += [line[idx].rstrip('.')]
-            d["seqs"] += [' '.join([l for l in line[idx + 1:] if l != '-'])]
+            d["seqs"] += [[l for l in line[idx + 1:] if l != '-']]
             d["alignment"] += [line[idx + 1:]]
 
     # normalize the alignment if the option is chosen

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -13,14 +13,14 @@ from lingpy.settings import rcParams
 from lingpy.data.ipa.sampa import reXS, xs
 
 
-def ipa2tokens(istring: str, **keywords):
+def ipa2tokens(sequence: str, **keywords):
     """
     Tokenize IPA-encoded strings.
 
     Parameters
     ----------
 
-    seq : str
+    sequence : str
         The input sequence that shall be tokenized.
 
     diacritics : {str, None} (default=None)
@@ -106,11 +106,11 @@ def ipa2tokens(istring: str, **keywords):
         raise ValueError("This part has not yet been implemented!")
 
     # check if input is a string
-    if not isinstance(istring, str):
+    if not isinstance(sequence, str):
         raise ValueError("Input must be a string")
 
     # check for pre-tokenized strings
-    if ' ' in istring:
+    if ' ' in sequence:
         raise ValueError("Input must not contain spaces")
 
     # create the list for the output
@@ -129,7 +129,7 @@ def ipa2tokens(istring: str, **keywords):
     semi_diacritics = kw['semi_diacritics']
     nogos = "_◦+"
 
-    for char in istring:
+    for char in sequence:
         # check for nasal stack and vowel environment
         if nasal:
             if char not in kw['vowels'] and char not in kw['diacritics']:

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -111,7 +111,7 @@ def ipa2tokens(istring: str, **keywords):
 
     # check for pre-tokenized strings
     if ' ' in istring:
-        return istring.split(' ')
+        raise ValueError("Input must not contain spaces")
 
     # create the list for the output
     out = []

--- a/src/lingpy/sequence/sound_classes.py
+++ b/src/lingpy/sequence/sound_classes.py
@@ -111,11 +111,7 @@ def ipa2tokens(istring: str, **keywords):
 
     # check for pre-tokenized strings
     if ' ' in istring:
-        out = istring.split(' ')
-        if istring.startswith('#'):
-            return out[1:-1]
-        else:
-            return out
+        return istring.split(' ')
 
     # create the list for the output
     out = []

--- a/tests/sequence/test_sound_classes.py
+++ b/tests/sequence/test_sound_classes.py
@@ -17,9 +17,6 @@ def test_ipa2tokens(test_data):
     seq = 'ʰto͡i'
     assert len(ipa2tokens(seq)) == 2
 
-    seq = 'th o x t a'
-    assert len(ipa2tokens(seq)) == len(seq.split(' '))
-
     with pytest.raises(ValueError):
         seq = ['t͡s', 'ɔ', 'y', 'ɡ', 'ə']
         ipa2tokens(seq)
@@ -173,11 +170,10 @@ def test_tokens2morphemes():
 
 
 def test_onoparse():
-    seq1 = "a k e r ts a n"
-    seq2 = seq1.split(' ')
-    out1 = ono_parse(seq1, output='pprint')
-    out2 = ono_parse(seq2, output='prostring')
-    out3 = ono_parse(seq1)
+    seq = "a k e r ts a n".split(' ')
+    out1 = ono_parse(seq, output='pprint')
+    out2 = ono_parse(seq, output='prostring')
+    out3 = ono_parse(seq)
 
     assert isinstance(out1, str)
     assert out3[0] == ('-', '#')

--- a/tests/sequence/test_sound_classes.py
+++ b/tests/sequence/test_sound_classes.py
@@ -20,9 +20,6 @@ def test_ipa2tokens(test_data):
     seq = 'th o x t a'
     assert len(ipa2tokens(seq)) == len(seq.split(' '))
 
-    seq = '# b l a #'
-    assert len(ipa2tokens(seq)) == len(seq.split(' ')) - 2
-
     with pytest.raises(ValueError):
         seq = ['t͡s', 'ɔ', 'y', 'ɡ', 'ə']
         ipa2tokens(seq)


### PR DESCRIPTION
This pull request offers a possible fix for #443. It achieves three main objectives.

**1. Removing word-initial and word-final # is removed from the `ipa2tokens` function.**

**2. Raising a value error when passing strings with spaces.**

Currently the `_list2msa` function stores `["seqs"]` as a space-separated string. This space-separated string gets passed into `ipa2tokens` in the `msa2html` function.

This pull request changes the behavior to storing 'seqs' as a list of tokens.
It also introduces a check for pre-tokenized strings in the `__init__` method of the `Multiple` class.

**3. Renaming `istring` variable to `sequence`.**