### PR TITLE
recent changes to igraph make lexstat-infomap not work

### DIFF
--- a/src/lingpy/algorithm/extra.py
+++ b/src/lingpy/algorithm/extra.py
@@ -201,13 +201,13 @@ def infomap_clustering(threshold, matrix, taxa=False, revert=False):
     G = igraph.Graph()
     # add vertices to the graph
     for i in range(len(matrix)):
-        G.add_vertex(i)
+        G.add_vertex(str(i))
 
     for i, row in enumerate(matrix):
         for j, cell in enumerate(row):
             if i < j:
                 if cell <= threshold:
-                    G.add_edge(i, j)
+                    G.add_edge(str(i), str(j))
 
     comps = G.community_infomap(edge_weights=None,
                                 vertex_weights=None)

--- a/src/lingpy/compare/lexstat.py
+++ b/src/lingpy/compare/lexstat.py
@@ -1459,7 +1459,7 @@ class LexStat(Wordlist):
                 # else:
                 if 1:
                     # extract the clusters
-                    clusters = [c[i] + k for i in range(len(matrix))]
+                    clusters = [c[str(i)] + k for i in range(len(matrix))]
 
                     # reassign the "k" value
                     k = max(clusters)


### PR DESCRIPTION
This recent patch to `python-igraph` breaks lexstat with infomap clustering:

https://github.com/igraph/python-igraph/commit/9d537949a9f3b4aded2c18c7609a05bbeeb788d0

i.e. you can't make vertices in an igraph graph which have ints as labels:

```
  File "/Users/simon/Desktop/lexst/lingpy/src/lingpy/compare/lexstat.py", line 1451, in cluster
    c = fclust(matrix, t)
        ^^^^^^^^^^^^^^^^^
  File "/Users/simon/Desktop/lexst/lingpy/src/lingpy/compare/lexstat.py", line 597, in infomap
    return extra.infomap_clustering(
  File "/Users/simon/Desktop/lexst/lingpy/src/lingpy/algorithm/extra.py", line 204, in infomap_clustering
    G.add_vertex(i)
  File "/Users/simon/Desktop/lexst/env/lib/pypy3.10/site-packages/igraph/basic.py", line 61, in _add_vertex
    raise TypeError("cannot use integers as vertex names; use strings instead")
TypeError: cannot use integers as vertex names; use strings instead
```

This PR fixes the problem by doing a dumb explicit cast to `str`. However a number of the tests fail because they were expecting `int` keys e.g.

```
___________________________________________________ test_clustering ____________________________________________________

mocker = <pytest_mock.plugin.MockerFixture object at 0x152cfe550>, Cluster = <Cluster_ id='5684323616'>
Igraph = <Igraph_ id='5698970768'>
matrix = [[0.0, 0.5, 0.67, 0.8, 0.2], [0.5, 0.0, 0.4, 0.7, 0.6], [0.67, 0.4, 0.0, 0.8, 0.8], [0.8, 0.7, 0.8, 0.0, 0.3], [0.2, 0.6, 0.8, 0.3, 0.0]]
taxa = ['German', 'Swedish', 'Icelandic', 'English', 'Dutch']

    def test_clustering(mocker, Cluster, Igraph, matrix, taxa):
        mocker.patch("lingpy.algorithm.extra.cluster", new=Cluster)
        mocker.patch("lingpy.algorithm.extra.igraph", new=Igraph)

        if not cluster:
            cluster1 = dbscan(0.25, matrix, taxa, revert=True)
            cluster2 = affinity_propagation(0.5, matrix, taxa, revert=True)
            assert cluster1[0] != cluster1[4]
            assert cluster2[0] != cluster2[4]

        if not igraph:
            cluster3 = infomap_clustering(0.4, matrix, taxa, revert=True)
>           assert cluster3[0] != cluster3[4]
E           KeyError: 0

tests/algorithm/test_extra.py:78: KeyError
```

Before I hack at the tests to fix this, I thought it best to discuss.

