### PR TITLE
deps: change python-igraph to igraph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     extras_require={
         "borrowing": ["matplotlib", "scipy"],
-        "cluster": ["python-igraph", "scikit-learn"],
+        "cluster": ["igraph", "scikit-learn"],
         "test": ["pytest", "coverage", "pytest-mock", "pytest-cov"],
         "dev": ["wheel", "twine", "sphinx", "tox"],
     },


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for why this is necessary.