### PR TITLE
Ipa2tk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Johann-Mattis List and Robert Forkel",
     author_email="info@lingpy.org",
-    version="2.6.10.dev0",
+    version="2.6.10",
     packages=find_packages(
         where="src",
         exclude=[
@@ -36,6 +36,7 @@ setup(
         'csvw>=1.5.6',
         'clldutils>=2.8.0',
         'pycldf>=1.7.0',
+        "lxml==4.8",
     ],
     extras_require={
         "borrowing": ["matplotlib", "scipy"],

--- a/src/lingpy/__init__.py
+++ b/src/lingpy/__init__.py
@@ -19,9 +19,9 @@ thirdparty --- Temporary Forks of Third-Party-Modules
 
 """
 
-__author__ = "Johann-Mattis List, and Robert Forkel (with contributions by Simon J. Greenhill, Tiago Tresoldi, Gereon Kaiping, Steven Moran, Taraka Rama, Johannes Dellert, Frank Nagel, and Peter Bouda, and Taraka Rama)"
-__date__ = "2021-11-26"
-__version__ = "2.6.10.dev0"
+__author__ = "Johann-Mattis List, and Robert Forkel"
+__date__ = "2023-10-13"
+__version__ = "2.6.10"
 
 # We exempt this module from QA, because it only provides import shortcuts.
 # flake8: noqa

--- a/src/lingpy/align/pairwise.py
+++ b/src/lingpy/align/pairwise.py
@@ -62,7 +62,14 @@ class Pairwise(object):
         # start to loop over data and create the stuff
         for k, (seqA, seqB) in enumerate(self.seqs):
             # get the tokens
-            tokA, tokB = tokenize(seqA), tokenize(seqB)
+            if isinstance(seqA, str):
+                tokA = tokenize(seqA) if not " " in seqA else seqA.split()
+            else:
+                tokA = [s for s in seqA]
+            if isinstance(seqB, str):
+                tokB = tokenize(seqB) if not " " in seqB else seqB.split()
+            else:
+                tokB = [s for s in seqB]
 
             # get the prostrings
             proA, proB = \

--- a/tests/align/test_pairwise.py
+++ b/tests/align/test_pairwise.py
@@ -11,6 +11,15 @@ from lingpy.data.model import Model
 def pair():
     return Pairwise('waldemar', 'vladimir')
 
+def test_pairwise_fix():
+    pair = Pairwise(list("mat"), list('mixt'))
+    pair.align()
+    assert pair.alignments[0][0][2] == "-"
+    pair = Pairwise("m a t", 'm i x t')
+    pair.align()
+    assert pair.alignments[0][0][2] == "-"
+
+
 
 def test_basics(pair):
     assert 'waldemar' in str(pair)


### PR DESCRIPTION
Fixes #453 but also fixes another problem introduced with the strict version of ipa2tokens that only accepts strings now as input (fix in pairwise module, tests added)