### PR TITLE
Sample pairs of indices in a memory efficient way

### DIFF
--- a/src/lingpy/compare/lexstat.py
+++ b/src/lingpy/compare/lexstat.py
@@ -742,9 +742,8 @@ class LexStat(Wordlist):
             seqs, pros, weights = {}, {}, {}
 
             # get a random distribution for all pairs
-            sample = random.sample(
-                [(i, j) for i in range(kw['rands']) for j in
-                    range(kw['rands'])], kw['runs'])
+            rands = list(range(kw['rands']))
+            sample = util.sample_random_pairs(rands, rands, kw['runs'])
 
             with util.pb(
                     desc='SEQUENCE GENERATION',
@@ -852,12 +851,8 @@ class LexStat(Wordlist):
                     prostrings = [
                             self[pair, self._prostrings] for pair in
                             self.pairs[tA, tB]]
-                    sample = [
-                            (x, y)
-                            for x in range(len(numbers)) for y in
-                            range(len(numbers))]
-                    if len(sample) > kw['runs']:
-                        sample = random.sample(sample, kw['runs'])
+                    indices = list(range(len(numbers)))
+                    sample = util.sample_random_pairs(indices, indices, kw['runs'])
 
                     for mode, gop, scale in kw['modes']:
                         corrs, included = calign.corrdist(

--- a/src/lingpy/util.py
+++ b/src/lingpy/util.py
@@ -299,3 +299,38 @@ def random_choices(population, weights=None, cum_weights=None, k=1):
     less_than = [[cw < r for cw in cum_weights] for r in rnd]
 
     return [population[lt.index(False)] for lt in less_than]
+
+
+def sample_random_pairs(list_a, list_b, n):
+    """
+    Sample `n` unique pairs from two lists, where each pair consists of one
+    element from `list_a` and one from `list_b`.
+    
+    Parameters
+    ----------
+    list_a : list
+        The first list from which elements will be sampled.
+    list_b : list
+        The second list from which elements will be sampled.
+    n : int
+        The number of unique pairs to sample. If `n` is greater than the total
+        number of possible pairs, it will sample all unique pairs.
+    Returns
+    -------
+    list
+        A list of unique pairs sampled from the input lists.
+    """
+    m, k = len(list_a), len(list_b)
+    total_pairs = m * k
+    n_pairs = min(n, total_pairs)
+    
+    # Sample unique indices in the range of possible pairs
+    indices = random.sample(range(total_pairs), n_pairs)
+    
+    # Map index to (i, j)
+    pairs = []
+    for idx in indices:
+        i = idx // k   # row index (for list_a)
+        j = idx % k    # column index (for list_b)
+        pairs.append((list_a[i], list_b[j]))
+    return pairs


### PR DESCRIPTION
When running LexStat .get_scorer(), the current way of generating pairs of numbers is to first generate all the possible pairs of numbers (n**2 of them), and then sample the required amount. For my run, this meant generating 450 million numbers, to select 1000 (the default). My computer did not like storing 450 million numbers in memory.

The proposed alternative works by generating the (1000) indices that correspond to the position in that theoretical n**2-long list, and generating only those 1000. This runs in O(n) and consumes O(n) memory, instead of previously O(n**2) for both.