### PR TITLE
Update sampa.py

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,12 @@ classifiers =
     Natural Language :: English
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
@@ -36,7 +38,7 @@ zip_safe = False
 packages = find:
 package_dir =
     = src
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     numpy
     appdirs
@@ -45,8 +47,7 @@ install_requires =
     csvw>=1.5.6
     clldutils>=2.8.0
     pycldf>=1.7.0
-    lxml==4.8; python_version<'3.9'
-    lxml; python_version>='3.9'
+    lxml
 include_package_data = True
 
 [options.packages.find]
@@ -106,7 +107,7 @@ skip_covered = true
 
 
 [tox:tox]
-envlist = py39, py310, py311, py312, py313
+envlist = py39, py310, py311, py312, py313, py314
 isolated_build = true
 skip_missing_interpreter = true
 

--- a/src/lingpy/convert/cldf.py
+++ b/src/lingpy/convert/cldf.py
@@ -1,7 +1,8 @@
 """
 Basic functions for the conversion from LingPy to CLDF and vice versa.
 """
-from clldutils.path import read_text
+import pathlib
+
 from clldutils.misc import slug
 
 from pycldf import Wordlist as CLDF_Wordlist
@@ -38,7 +39,7 @@ def to_cldf(wordlist, path='cldf', source_path=None, ref="cogid",
     # create cldf-dataset
     ds = CLDF_Wordlist.in_dir(path)
     # add sources if they are available
-    ds.add_sources(read_text(source_path) if source_path else '')
+    ds.add_sources(pathlib.Path(source_path).read_text(encoding='utf8') if source_path else '')
     # add components
     ds.add_component('LanguageTable')
     ds.add_component('ParameterTable', 'Concepticon_ID')

--- a/src/lingpy/data/ipa/sampa.py
+++ b/src/lingpy/data/ipa/sampa.py
@@ -17,14 +17,14 @@ xsdata = []
 _xsKeys = [' ']
 xs = {' ': ' '}
 
-for line in codecs.open(data_path('ipa', 'sampa.csv'), 'r', 'utf-8'):
-    line = line.strip('\n').strip('\r')
-    if line and not line.startswith('#'):
-        key,val = line.split('\t')
-        if key in xs and xs[key] != val:  # pragma: no cover
-            raise ValueError("Keys encode too many values.")
-        _xsKeys.append(key)
-        xs[key] = eval('"""' + val + '"""')
+with codecs.open(data_path('ipa', 'sampa.csv'), 'r', 'utf-8') as handle:
+    for line in handle:
+        if line and not line.startswith('#'):
+            key,val = line.split('\t')
+            if key in xs and xs[key] != val:  # pragma: no cover
+                raise ValueError("Keys encode too many values.")
+            _xsKeys.append(key)
+            xs[key] = eval('"""' + val + '"""')
 
 _kk = []
 for _k in _xsKeys:

--- a/src/lingpy/data/ipa/sampa.py
+++ b/src/lingpy/data/ipa/sampa.py
@@ -19,6 +19,7 @@ xs = {' ': ' '}
 
 with codecs.open(data_path('ipa', 'sampa.csv'), 'r', 'utf-8') as handle:
     for line in handle:
+        line = line.strip('\n').strip('\r')
         if line and not line.startswith('#'):
             key,val = line.split('\t')
             if key in xs and xs[key] != val:  # pragma: no cover

--- a/src/lingpy/evaluate/apa.py
+++ b/src/lingpy/evaluate/apa.py
@@ -1,11 +1,11 @@
 """
 Basic module for the comparison of automatic phonetic alignments.
 """
+import functools
 from collections import namedtuple, defaultdict
 from itertools import combinations
 
 import numpy as np
-from clldutils.misc import lazyproperty
 
 from lingpy.algorithm import misc
 from lingpy import log
@@ -43,7 +43,7 @@ class EvalMSA(Eval):
     --------
     ~lingpy.evaluate.apa.EvalPSA
     """
-    @lazyproperty
+    @functools.cached_property
     def c_scores(self):
         """
         Calculate the c-scores.
@@ -443,7 +443,7 @@ class EvalPSA(Eval):
 
         return score / len(self.gold.alignments)
 
-    @lazyproperty
+    @functools.cached_property
     def pairwise_column_scores(self):
         """
         Compute the different column scores for pairwise alignments. The method

--- a/tests/sequence/test_sound_classes.py
+++ b/tests/sequence/test_sound_classes.py
@@ -128,10 +128,15 @@ def test_check_tokens():
     assert check_tokens('th o x T e r'.split(' '))[0] == (3, 'T')
 
 
-def test_sampa2uni():
-    seq = 'tʰɔxtər'
-    sampa = eval('"' + sampa2uni('t_hOxt@r') + '"')
-    assert sampa == seq  # or sampa2 == seq
+@pytest.mark.parametrize(
+    'sampa,ipa',
+    [
+        ('t_hOxt@r', 'tʰɔxtər'),
+    ]
+)
+def test_sampa2uni(sampa, ipa):
+    from_sampa = eval('"' + sampa2uni(sampa) + '"')
+    assert from_sampa == ipa  # or sampa2 == seq
 
 
 def test_pgrams():


### PR DESCRIPTION
sampa.py doesn't close a file handler. 

This causes a downstream package I'm building to crash when running tests (I think the test runner garbage collects but can't find the handle) although this is claude code's interpretation so YMMV.

Here's the crash that kills pytest:
```
object address  : 0x15b1f86a0
object refcount : 3
object type     : 0x10094dbd0
object type name: ValueError
object repr     : ValueError('I/O operation on closed file.')
lost sys.stderr
```